### PR TITLE
Fix bug that overwrites query options for blocking timeout

### DIFF
--- a/src/main/java/com/orbitz/consul/util/ClientUtil.java
+++ b/src/main/java/com/orbitz/consul/util/ClientUtil.java
@@ -88,10 +88,6 @@ public class ClientUtil {
                                                  QueryOptions queryOptions,
                                                  GenericType<T> type,
                                                  ConsulResponseCallback<T> callback) {
-        if(queryOptions.isBlocking()) {
-            queryOptions = QueryOptionsBuilder.builder().queryOptions(queryOptions)
-                    .blockMinutes(5, queryOptions.getIndex()).build();
-        }
 
         target = catalogConfig(target, catalogOptions);
         target = queryConfig(target, queryOptions);


### PR DESCRIPTION
When we call into the health client from consul-service-discovery, we set the query options:

healthClient.getHealthyNodesAsync(serviceName, builder().blockMinutes(TIMEOUT_IN_MINS, startIndex).build(), consulDiscoveryCallback);

When we provide a timeout value like this, the builder marks the "blocking" flag as true in the query options. But then we are guaranteed to overwrite the timeout values that we set because of the logic below (isBlocking() is true if "wait" has been set to any value)

public static <T> void response(WebTarget target, CatalogOptions catalogOptions,
                                                 QueryOptions queryOptions,
                                                 GenericType<T> type,
                                                 ConsulResponseCallback<T> callback) {
        if(queryOptions.isBlocking()) {
            queryOptions = QueryOptionsBuilder.builder().queryOptions(queryOptions)
                    .blockMinutes(5, queryOptions.getIndex()).build();
        }

I think we can simply remove this block. If it is blocking, then someone has already set the timeout in the query options.
