### PR TITLE
Inject the same Consul host/port everywhere for integration tests

### DIFF
--- a/src/test/java/com/orbitz/consul/BaseIntegrationTest.java
+++ b/src/test/java/com/orbitz/consul/BaseIntegrationTest.java
@@ -9,10 +9,12 @@ public abstract class BaseIntegrationTest {
 
     protected static Consul client;
 
+    protected static HostAndPort defaultClientHostAndPort = HostAndPort.fromParts("localhost", 8500);
+
     @BeforeClass
     public static void beforeClass() {
         client = Consul.builder()
-                .withHostAndPort(HostAndPort.fromParts("localhost", 8500))
+                .withHostAndPort(defaultClientHostAndPort)
                 .withReadTimeoutMillis(Duration.ofSeconds(2).toMillis())
                 .build();
     }

--- a/src/test/java/com/orbitz/consul/LifecycleTests.java
+++ b/src/test/java/com/orbitz/consul/LifecycleTests.java
@@ -1,6 +1,5 @@
 package com.orbitz.consul;
 
-import com.google.common.net.HostAndPort;
 import okhttp3.internal.Util;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -14,11 +13,11 @@ import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Mockito.*;
 
-public class LifecycleTests {
+public class LifecycleTests extends BaseIntegrationTest {
 
     @Test
     public void shouldBeDestroyable() {
-        Consul client = Consul.builder().withHostAndPort(HostAndPort.fromParts("localhost", 8500)).build();
+        Consul client = Consul.builder().withHostAndPort(defaultClientHostAndPort).build();
         client.destroy();
     }
 
@@ -33,7 +32,7 @@ public class LifecycleTests {
 
         doReturn(new ArrayList<>()).when(executorService).shutdownNow();
 
-        Consul client = Consul.builder().withHostAndPort(HostAndPort.fromParts("localhost", 8500)).withExecutorService(executorService).build();
+        Consul client = Consul.builder().withHostAndPort(defaultClientHostAndPort).withExecutorService(executorService).build();
         client.destroy();
 
         verify(executorService, times(1)).shutdownNow();
@@ -51,7 +50,7 @@ public class LifecycleTests {
                 System.out.println("This is a Task printing a message in Thread " + currentThread);
             }
         });
-        Consul client = Consul.builder().withHostAndPort(HostAndPort.fromParts("localhost", 8500)).withExecutorService(executorService).build();
+        Consul client = Consul.builder().withHostAndPort(defaultClientHostAndPort).withExecutorService(executorService).build();
         client.destroy();
     }
 
@@ -68,7 +67,7 @@ public class LifecycleTests {
             }
         });
 
-        Consul client = Consul.builder().withHostAndPort(HostAndPort.fromParts("localhost", 8500)).withExecutorService(executorService).build();
+        Consul client = Consul.builder().withHostAndPort(defaultClientHostAndPort).withExecutorService(executorService).build();
 
         // do not destroy the Consul client
         // in order to verify that the Java VM does not terminate, and waits for some time (keepAliveTime parameter of the ThreadPoolExecutor)

--- a/src/test/java/com/orbitz/consul/util/CustomBuilderTest.java
+++ b/src/test/java/com/orbitz/consul/util/CustomBuilderTest.java
@@ -1,6 +1,5 @@
 package com.orbitz.consul.util;
 
-import com.google.common.net.HostAndPort;
 import com.orbitz.consul.BaseIntegrationTest;
 import com.orbitz.consul.Consul;
 import com.orbitz.consul.model.agent.Agent;
@@ -9,7 +8,6 @@ import org.junit.Test;
 import java.net.Proxy;
 import java.net.UnknownHostException;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class CustomBuilderTest extends BaseIntegrationTest{
@@ -17,7 +15,7 @@ public class CustomBuilderTest extends BaseIntegrationTest{
     @Test
     public void shouldConnectWithCustomTimeouts() throws UnknownHostException {
         Consul client = Consul.builder()
-                .withHostAndPort(HostAndPort.fromParts("localhost", 8500))
+                .withHostAndPort(defaultClientHostAndPort)
                 .withProxy(Proxy.NO_PROXY)
                 .withConnectTimeoutMillis(10000)
                 .withReadTimeoutMillis(3600000)


### PR DESCRIPTION
Most tests use the consul client created in BaseIntegrationTest.
However, two classes do differently.
If you do not use "localhost:8500" for your tests, you need to change it 5 times.
Make every tests use the same client address.