### PR TITLE
Upgrade Consul version in test to 1.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: java
 services: docker
 before_install:
-  - docker run -d -p 127.0.0.1:8500:8500 consul:0.7.2
+  - docker run -d -p 127.0.0.1:8500:8500 consul:1.0.3 agent -dev -client 0.0.0.0 --enable-script-checks=true
+
 jdk:
   - oraclejdk8
 script: mvn clean test

--- a/src/test/java/com/orbitz/consul/EventTests.java
+++ b/src/test/java/com/orbitz/consul/EventTests.java
@@ -16,7 +16,7 @@ public class EventTests extends BaseIntegrationTest {
     public void shouldFire() throws InterruptedException {
         EventClient eventClient = client.eventClient();
 
-        String name = RandomStringUtils.random(10);
+        String name = RandomStringUtils.random(10, true, true);
         Event fired = eventClient.fireEvent(name);
 
         Synchroniser.pause(Duration.ofMillis(100));


### PR DESCRIPTION
As described in issue #303, the consul version is quite old in the tests.
We here upgrade it to the last version.

In this version, we need to:
 - enabled script checks in command line
This is needed to run test AgentTests#shouldRegisterNodeScriptCheck
According to changelog: 0.9.0 (July 20, 2017) "agent: Added a new enable_script_checks configuration option that defaults to false, meaning that in order to allow an agent to run health checks that execute scripts, this will need to be configured and set to true. This provides a safer out-of-the-box configuration for Consul where operators must opt-in to allow script-based health checks. [GH-3087]"
 - add "agent -dev -client 0.0.0.0" in docker command line:
This is the default command run by the docker image. However, we cannot add option without adding the default command line in the actual command line
 - set true to letters and numbers in RandomStringUtils#random
This is needed to ensure that the random string contains only numbers and letters i.e. printable characters.
According to changelog: 1.0.3 (Junuary 24, 2017) "agent: Updated Consul's HTTP server to ban all URLs containing non-printable characters (a bad request status will be returned for these cases). This affects some user-facing areas like key/value entry key names which are carried in URLs. [GH-3762]"