### PR TITLE
Add event monitoring

### DIFF
--- a/src/main/java/com/orbitz/consul/AclClient.java
+++ b/src/main/java/com/orbitz/consul/AclClient.java
@@ -14,8 +14,6 @@ import retrofit2.http.Path;
 
 import java.util.List;
 
-import static com.orbitz.consul.util.Http.*;
-
 public class AclClient extends BaseClient {
 
     private static String CLIENT_NAME = "acl";
@@ -28,27 +26,27 @@ public class AclClient extends BaseClient {
     }
 
     public String createAcl(AclToken aclToken) {
-        return extract(api.createAcl(aclToken)).id();
+        return http.extract(api.createAcl(aclToken)).id();
     }
 
     public void updateAcl(AclToken aclToken) {
-        handle(api.updateAcl(aclToken));
+        http.handle(api.updateAcl(aclToken));
     }
 
     public void destroyAcl(String id) {
-        handle(api.destroyAcl(id));
+        http.handle(api.destroyAcl(id));
     }
 
     public List<AclResponse> getAclInfo(String id) {
-        return extract(api.getAclInfo(id));
+        return http.extract(api.getAclInfo(id));
     }
 
     public String cloneAcl(String id) {
-        return extract(api.cloneAcl(id)).id();
+        return http.extract(api.cloneAcl(id)).id();
     }
 
     public List<AclResponse> listAcls() {
-        return extract(api.listAcls());
+        return http.extract(api.listAcls());
     }
 
     interface Api {

--- a/src/main/java/com/orbitz/consul/AclClient.java
+++ b/src/main/java/com/orbitz/consul/AclClient.java
@@ -4,6 +4,7 @@ import com.orbitz.consul.config.ClientConfig;
 import com.orbitz.consul.model.acl.AclResponse;
 import com.orbitz.consul.model.acl.AclToken;
 import com.orbitz.consul.model.acl.AclTokenId;
+import com.orbitz.consul.monitoring.ClientEventCallback;
 import retrofit2.Call;
 import retrofit2.Retrofit;
 import retrofit2.http.Body;
@@ -17,10 +18,12 @@ import static com.orbitz.consul.util.Http.*;
 
 public class AclClient extends BaseClient {
 
+    private static String CLIENT_NAME = "acl";
+
     private final Api api;
 
-    AclClient(Retrofit retrofit, ClientConfig config) {
-        super(config);
+    AclClient(Retrofit retrofit, ClientConfig config, ClientEventCallback eventCallback) {
+        super(CLIENT_NAME, config, eventCallback);
         this.api = retrofit.create(Api.class);
     }
 

--- a/src/main/java/com/orbitz/consul/AgentClient.java
+++ b/src/main/java/com/orbitz/consul/AgentClient.java
@@ -19,9 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.orbitz.consul.util.Http.extract;
-import static com.orbitz.consul.util.Http.handle;
-
 /**
  * HTTP Client for /v1/agent/ endpoints.
  *
@@ -182,7 +179,7 @@ public class AgentClient extends BaseClient {
      * @param options An optional QueryOptions instance.
      */
     public void register(Registration registration, QueryOptions options) {
-        handle(api.register(registration, options.toQuery()));
+        http.handle(api.register(registration, options.toQuery()));
     }
 
     public void register(Registration registration) {
@@ -194,7 +191,7 @@ public class AgentClient extends BaseClient {
      * De-register a particular service from the Consul Agent.
      */
     public void deregister(String serviceId, QueryOptions options) {
-        handle(api.deregister(serviceId, options.toQuery()));
+        http.handle(api.deregister(serviceId, options.toQuery()));
     }
 
     /**
@@ -342,7 +339,7 @@ public class AgentClient extends BaseClient {
      * @param check The Check to register.
      */
     public void registerCheck(Check check) {
-        handle(api.registerCheck(check));
+        http.handle(api.registerCheck(check));
     }
 
     /**
@@ -351,7 +348,7 @@ public class AgentClient extends BaseClient {
      * @param checkId the id of the Check to deregister
      */
     public void deregisterCheck(String checkId) {
-        handle(api.deregisterCheck(checkId));
+        http.handle(api.deregisterCheck(checkId));
     }
 
     /**
@@ -362,7 +359,7 @@ public class AgentClient extends BaseClient {
      * @return The Agent information.
      */
     public Agent getAgent() {
-        return extract(api.getAgent());
+        return http.extract(api.getAgent());
     }
 
     /**
@@ -373,7 +370,7 @@ public class AgentClient extends BaseClient {
      * @return Map of Check ID to Checks.
      */
     public Map<String, HealthCheck> getChecks() {
-        return extract(api.getChecks());
+        return http.extract(api.getChecks());
     }
 
     /**
@@ -384,7 +381,7 @@ public class AgentClient extends BaseClient {
      * @return Map of Service ID to Services.
      */
     public Map<String, Service> getServices() {
-        return extract(api.getServices());
+        return http.extract(api.getServices());
     }
 
     /**
@@ -395,7 +392,7 @@ public class AgentClient extends BaseClient {
      * @return List of Members.
      */
     public List<Member> getMembers() {
-        return extract(api.getMembers());
+        return http.extract(api.getMembers());
     }
 
     /**
@@ -406,7 +403,7 @@ public class AgentClient extends BaseClient {
      * @param node
      */
     public void forceLeave(String node) {
-        handle(api.forceLeave());
+        http.handle(api.forceLeave());
     }
 
     /**
@@ -420,7 +417,7 @@ public class AgentClient extends BaseClient {
         try {
             Map<String, String> query = note == null ? Collections.emptyMap() : ImmutableMap.of("note", note);
 
-            handle(api.check(state.getPath(), checkId, query));
+            http.handle(api.check(state.getPath(), checkId, query));
         } catch (Exception ex) {
             throw new NotRegisteredException("Error checking state", ex);
         }
@@ -431,11 +428,6 @@ public class AgentClient extends BaseClient {
      * then delegates to check(String checkId, State state, String note)
      * This method only works with TTL checks that have not been given a custom
      * name.
-     *
-     * @param serviceId
-     * @param state
-     * @param note
-     * @throws NotRegisteredException
      */
     public void checkTtl(String serviceId, State state, String note) throws NotRegisteredException {
         check("service:" + serviceId, state, note);
@@ -551,7 +543,7 @@ public class AgentClient extends BaseClient {
         boolean result = true;
 
         try {
-            handle(api.join(address, query));
+            http.handle(api.join(address, query));
         } catch(Exception ex) {
             result = false;
         }
@@ -567,7 +559,7 @@ public class AgentClient extends BaseClient {
      *               maintenance mode, otherwise <code>false</code>.
      */
     public void toggleMaintenanceMode(String serviceId, boolean enable) {
-        handle(api.toggleMaintenanceMode(serviceId,
+        http.handle(api.toggleMaintenanceMode(serviceId,
                 ImmutableMap.of("enable", Boolean.toString(enable))));
     }
 
@@ -582,7 +574,7 @@ public class AgentClient extends BaseClient {
     public void toggleMaintenanceMode(String serviceId,
                                       boolean enable,
                                       String reason) {
-        handle(api.toggleMaintenanceMode(serviceId,
+        http.handle(api.toggleMaintenanceMode(serviceId,
                 ImmutableMap.of("enable", Boolean.toString(enable),
                                 "reason", reason)));
     }

--- a/src/main/java/com/orbitz/consul/AgentClient.java
+++ b/src/main/java/com/orbitz/consul/AgentClient.java
@@ -7,6 +7,7 @@ import com.orbitz.consul.model.State;
 import com.orbitz.consul.model.agent.*;
 import com.orbitz.consul.model.health.HealthCheck;
 import com.orbitz.consul.model.health.Service;
+import com.orbitz.consul.monitoring.ClientEventCallback;
 import com.orbitz.consul.option.QueryOptions;
 import retrofit2.Call;
 import retrofit2.Retrofit;
@@ -28,6 +29,8 @@ import static com.orbitz.consul.util.Http.handle;
  */
 public class AgentClient extends BaseClient {
 
+    private static String CLIENT_NAME = "agent";
+
     private final Api api;
 
     /**
@@ -35,8 +38,8 @@ public class AgentClient extends BaseClient {
      *
      * @param retrofit The {@link Retrofit} to build a client from.
      */
-    AgentClient(Retrofit retrofit, ClientConfig config) {
-        super(config);
+    AgentClient(Retrofit retrofit, ClientConfig config, ClientEventCallback eventCallback) {
+        super(CLIENT_NAME, config, eventCallback);
         this.api = retrofit.create(Api.class);
     }
 

--- a/src/main/java/com/orbitz/consul/BaseClient.java
+++ b/src/main/java/com/orbitz/consul/BaseClient.java
@@ -3,15 +3,18 @@ package com.orbitz.consul;
 import com.orbitz.consul.config.ClientConfig;
 import com.orbitz.consul.monitoring.ClientEventCallback;
 import com.orbitz.consul.monitoring.ClientEventHandler;
+import com.orbitz.consul.util.Http;
 
 abstract class BaseClient {
 
     private final ClientConfig config;
     private final ClientEventHandler eventHandler;
+    protected final Http http;
 
     protected BaseClient(String name, ClientConfig config, ClientEventCallback eventCallback) {
         this.config = config;
         this.eventHandler = new ClientEventHandler(name, eventCallback);
+        this.http = new Http(eventHandler);
     }
 
     public ClientConfig getConfig() {

--- a/src/main/java/com/orbitz/consul/BaseClient.java
+++ b/src/main/java/com/orbitz/consul/BaseClient.java
@@ -1,16 +1,22 @@
 package com.orbitz.consul;
 
 import com.orbitz.consul.config.ClientConfig;
+import com.orbitz.consul.monitoring.ClientEventCallback;
+import com.orbitz.consul.monitoring.ClientEventHandler;
 
 abstract class BaseClient {
 
     private final ClientConfig config;
+    private final ClientEventHandler eventHandler;
 
-    protected BaseClient(ClientConfig config) {
+    protected BaseClient(String name, ClientConfig config, ClientEventCallback eventCallback) {
         this.config = config;
+        this.eventHandler = new ClientEventHandler(name, eventCallback);
     }
 
     public ClientConfig getConfig() {
         return config;
     }
+
+    public ClientEventHandler getEventHandler() { return eventHandler; }
 }

--- a/src/main/java/com/orbitz/consul/CatalogClient.java
+++ b/src/main/java/com/orbitz/consul/CatalogClient.java
@@ -8,6 +8,7 @@ import com.orbitz.consul.model.catalog.CatalogNode;
 import com.orbitz.consul.model.catalog.CatalogRegistration;
 import com.orbitz.consul.model.catalog.CatalogService;
 import com.orbitz.consul.model.health.Node;
+import com.orbitz.consul.monitoring.ClientEventCallback;
 import com.orbitz.consul.option.QueryOptions;
 import com.orbitz.consul.util.Http;
 import retrofit2.Call;
@@ -25,6 +26,8 @@ import static com.orbitz.consul.util.Http.handle;
  */
 public class CatalogClient extends BaseClient {
 
+    private static String CLIENT_NAME = "catalog";
+
     private final Api api;
 
     /**
@@ -32,8 +35,8 @@ public class CatalogClient extends BaseClient {
      *
      * @param retrofit The {@link Retrofit} to build a client from.
      */
-    CatalogClient(Retrofit retrofit, ClientConfig config) {
-        super(config);
+    CatalogClient(Retrofit retrofit, ClientConfig config, ClientEventCallback eventCallback) {
+        super(CLIENT_NAME, config, eventCallback);
         this.api = retrofit.create(Api.class);
     }
 

--- a/src/main/java/com/orbitz/consul/CatalogClient.java
+++ b/src/main/java/com/orbitz/consul/CatalogClient.java
@@ -10,16 +10,12 @@ import com.orbitz.consul.model.catalog.CatalogService;
 import com.orbitz.consul.model.health.Node;
 import com.orbitz.consul.monitoring.ClientEventCallback;
 import com.orbitz.consul.option.QueryOptions;
-import com.orbitz.consul.util.Http;
 import retrofit2.Call;
 import retrofit2.Retrofit;
 import retrofit2.http.*;
 
 import java.util.List;
 import java.util.Map;
-
-import static com.orbitz.consul.util.Http.extractConsulResponse;
-import static com.orbitz.consul.util.Http.handle;
 
 /**
  * HTTP Client for /v1/catalog/ endpoints.
@@ -48,7 +44,7 @@ public class CatalogClient extends BaseClient {
      * @return A list of datacenter names.
      */
     public List<String> getDatacenters() {
-        return Http.extract(api.getDatacenters());
+        return http.extract(api.getDatacenters());
     }
 
     /**
@@ -73,7 +69,7 @@ public class CatalogClient extends BaseClient {
      * {@link com.orbitz.consul.model.health.Node} objects.
      */
     public ConsulResponse<List<Node>> getNodes(QueryOptions queryOptions) {
-        return extractConsulResponse(api.getNodes(queryOptions.toQuery(),
+        return http.extractConsulResponse(api.getNodes(queryOptions.toQuery(),
                 queryOptions.getTag(), queryOptions.getNodeMeta()));
     }
 
@@ -87,7 +83,7 @@ public class CatalogClient extends BaseClient {
      *                     {@link com.orbitz.consul.model.health.Node} objects.
      */
     public void getNodes(QueryOptions queryOptions, ConsulResponseCallback<List<Node>> callback) {
-        extractConsulResponse(api.getNodes(queryOptions.toQuery(), queryOptions.getTag(),
+        http.extractConsulResponse(api.getNodes(queryOptions.toQuery(), queryOptions.getTag(),
                 queryOptions.getNodeMeta()), callback);
     }
 
@@ -111,7 +107,7 @@ public class CatalogClient extends BaseClient {
      * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a map of service name to list of tags.
      */
     public ConsulResponse<Map<String, List<String>>> getServices(QueryOptions queryOptions) {
-        return extractConsulResponse(api.getServices(queryOptions.toQuery(),
+        return http.extractConsulResponse(api.getServices(queryOptions.toQuery(),
                 queryOptions.getTag(), queryOptions.getNodeMeta()));
     }
 
@@ -137,7 +133,7 @@ public class CatalogClient extends BaseClient {
      * {@link com.orbitz.consul.model.catalog.CatalogService} objects.
      */
     public ConsulResponse<List<CatalogService>> getService(String service, QueryOptions queryOptions) {
-        return extractConsulResponse(api.getService(service, queryOptions.toQuery(),
+        return http.extractConsulResponse(api.getService(service, queryOptions.toQuery(),
                 queryOptions.getTag(), queryOptions.getNodeMeta()));
     }
 
@@ -161,7 +157,7 @@ public class CatalogClient extends BaseClient {
      * @return A list of matching {@link com.orbitz.consul.model.catalog.CatalogService} objects.
      */
     public ConsulResponse<CatalogNode> getNode(String node, QueryOptions queryOptions) {
-        return extractConsulResponse(api.getNode(node, queryOptions.toQuery(),
+        return http.extractConsulResponse(api.getNode(node, queryOptions.toQuery(),
                 queryOptions.getTag(), queryOptions.getNodeMeta()));
     }
 
@@ -184,7 +180,7 @@ public class CatalogClient extends BaseClient {
      * @param registration A {@link CatalogRegistration}
      */
     public void register(CatalogRegistration registration, QueryOptions options) {
-        handle(api.register(registration, options.toQuery()));
+        http.handle(api.register(registration, options.toQuery()));
     }
 
     /**
@@ -206,7 +202,7 @@ public class CatalogClient extends BaseClient {
      * @param deregistration A {@link CatalogDeregistration}
      */
     public void deregister(CatalogDeregistration deregistration, QueryOptions options) {
-        handle(api.deregister(deregistration, options.toQuery()));
+        http.handle(api.deregister(deregistration, options.toQuery()));
     }
 
     /**

--- a/src/main/java/com/orbitz/consul/Consul.java
+++ b/src/main/java/com/orbitz/consul/Consul.java
@@ -7,6 +7,7 @@ import com.google.common.io.BaseEncoding;
 import com.google.common.net.HostAndPort;
 import com.orbitz.consul.config.CacheConfig;
 import com.orbitz.consul.config.ClientConfig;
+import com.orbitz.consul.monitoring.ClientEventCallback;
 import com.orbitz.consul.util.Jackson;
 import com.orbitz.consul.cache.TimeoutInterceptor;
 import com.orbitz.consul.util.bookend.ConsulBookend;
@@ -245,6 +246,7 @@ public class Consul {
         private Long writeTimeoutMillis;
         private ExecutorService executorService;
         private ClientConfig clientConfig;
+        private ClientEventCallback clientEventCallback;
 
         {
             try {
@@ -508,6 +510,19 @@ public class Consul {
         }
 
         /**
+         * Sets the event callback for the clients.
+         * The callback will be called by the consul client after each event.
+         *
+         * @param callback the callback to call.
+         * @return The Builder
+         */
+        public Builder withClientEventCallback(ClientEventCallback callback) {
+            this.clientEventCallback = callback;
+
+            return this;
+        }
+
+        /**
          * Constructs a new {@link Consul} client.
          *
          * @return A new Consul client.
@@ -541,17 +556,21 @@ public class Consul {
                 throw new RuntimeException(e);
             }
 
-            AgentClient agentClient = new AgentClient(retrofit, config);
-            HealthClient healthClient = new HealthClient(retrofit, config);
-            KeyValueClient keyValueClient = new KeyValueClient(retrofit, config);
-            CatalogClient catalogClient = new CatalogClient(retrofit, config);
-            StatusClient statusClient = new StatusClient(retrofit, config);
-            SessionClient sessionClient = new SessionClient(retrofit, config);
-            EventClient eventClient = new EventClient(retrofit, config);
-            PreparedQueryClient preparedQueryClient = new PreparedQueryClient(retrofit, config);
-            CoordinateClient coordinateClient = new CoordinateClient(retrofit, config);
-            OperatorClient operatorClient = new OperatorClient(retrofit, config);
-            AclClient aclClient = new AclClient(retrofit, config);
+            ClientEventCallback eventCallback = clientEventCallback != null ?
+                    clientEventCallback :
+                    new ClientEventCallback(){};
+
+            AgentClient agentClient = new AgentClient(retrofit, config, eventCallback);
+            HealthClient healthClient = new HealthClient(retrofit, config, eventCallback);
+            KeyValueClient keyValueClient = new KeyValueClient(retrofit, config, eventCallback);
+            CatalogClient catalogClient = new CatalogClient(retrofit, config, eventCallback);
+            StatusClient statusClient = new StatusClient(retrofit, config, eventCallback);
+            SessionClient sessionClient = new SessionClient(retrofit, config, eventCallback);
+            EventClient eventClient = new EventClient(retrofit, config, eventCallback);
+            PreparedQueryClient preparedQueryClient = new PreparedQueryClient(retrofit, config, eventCallback);
+            CoordinateClient coordinateClient = new CoordinateClient(retrofit, config, eventCallback);
+            OperatorClient operatorClient = new OperatorClient(retrofit, config, eventCallback);
+            AclClient aclClient = new AclClient(retrofit, config, eventCallback);
 
             if (ping) {
                 agentClient.ping();

--- a/src/main/java/com/orbitz/consul/CoordinateClient.java
+++ b/src/main/java/com/orbitz/consul/CoordinateClient.java
@@ -14,8 +14,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static com.orbitz.consul.util.Http.extract;
-
 /**
  * HTTP Client for /v1/coordinate/ endpoints.
  *
@@ -38,11 +36,11 @@ public class CoordinateClient extends BaseClient {
     }
 
     public List<Datacenter> getDatacenters() {
-        return extract(api.getDatacenters());
+        return http.extract(api.getDatacenters());
     }
 
     public List<Coordinate> getNodes(String dc) {
-        return extract(api.getNodes(dcQuery(dc)));
+        return http.extract(api.getNodes(dcQuery(dc)));
     }
 
     public List<Coordinate> getNodes() {

--- a/src/main/java/com/orbitz/consul/CoordinateClient.java
+++ b/src/main/java/com/orbitz/consul/CoordinateClient.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.orbitz.consul.config.ClientConfig;
 import com.orbitz.consul.model.coordinate.Coordinate;
 import com.orbitz.consul.model.coordinate.Datacenter;
+import com.orbitz.consul.monitoring.ClientEventCallback;
 import retrofit2.Call;
 import retrofit2.Retrofit;
 import retrofit2.http.GET;
@@ -22,6 +23,8 @@ import static com.orbitz.consul.util.Http.extract;
  */
 public class CoordinateClient extends BaseClient {
 
+    private static String CLIENT_NAME = "coordinate";
+
     private final Api api;
 
     /**
@@ -29,8 +32,8 @@ public class CoordinateClient extends BaseClient {
      *
      * @param retrofit The {@link Retrofit} to build a client from.
      */
-    CoordinateClient(Retrofit retrofit, ClientConfig config) {
-        super(config);
+    CoordinateClient(Retrofit retrofit, ClientConfig config, ClientEventCallback eventCallback) {
+        super(CLIENT_NAME, config, eventCallback);
         this.api = retrofit.create(Api.class);
     }
 

--- a/src/main/java/com/orbitz/consul/EventClient.java
+++ b/src/main/java/com/orbitz/consul/EventClient.java
@@ -1,8 +1,10 @@
 package com.orbitz.consul;
 
 import com.google.common.collect.ImmutableMap;
+import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.async.EventResponseCallback;
 import com.orbitz.consul.config.ClientConfig;
+import com.orbitz.consul.model.ConsulResponse;
 import com.orbitz.consul.model.EventResponse;
 import com.orbitz.consul.model.ImmutableEventResponse;
 import com.orbitz.consul.model.event.Event;
@@ -13,18 +15,12 @@ import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import org.apache.commons.lang3.StringUtils;
 import retrofit2.Call;
-import retrofit2.Callback;
-import retrofit2.Response;
 import retrofit2.Retrofit;
 import retrofit2.http.*;
 
-import java.io.IOException;
-import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import static com.orbitz.consul.util.Http.extract;
 
 /**
  * HTTP Client for /v1/event/ endpoints.
@@ -58,7 +54,7 @@ public class EventClient extends BaseClient {
      * @return The newly created {@link com.orbitz.consul.model.event.Event}.
      */
     public Event fireEvent(String name, EventOptions eventOptions, String payload) {
-        return extract(api.fireEvent(name,
+        return http.extract(api.fireEvent(name,
                 RequestBody.create(MediaType.parse("text/plain"), payload),
                 eventOptions.toQuery()));
     }
@@ -85,7 +81,7 @@ public class EventClient extends BaseClient {
      * @return The newly created {@link com.orbitz.consul.model.event.Event}.
      */
     public Event fireEvent(String name, EventOptions eventOptions) {
-        return extract(api.fireEvent(name, eventOptions.toQuery()));
+        return http.extract(api.fireEvent(name, eventOptions.toQuery()));
     }
 
     /**
@@ -114,7 +110,8 @@ public class EventClient extends BaseClient {
     public EventResponse listEvents(String name, QueryOptions queryOptions) {
         Map<String, String> query = StringUtils.isNotEmpty(name) ? ImmutableMap.of("name", name) : Collections.emptyMap();
 
-        return response(api.listEvents(query));
+        ConsulResponse<List<Event>> response = http.extractConsulResponse(api.listEvents(query));
+        return ImmutableEventResponse.of(response.getResponse(), response.getIndex());
     }
 
     /**
@@ -167,7 +164,21 @@ public class EventClient extends BaseClient {
     public void listEvents(String name, QueryOptions queryOptions, EventResponseCallback callback) {
         Map<String, String> query = StringUtils.isNotEmpty(name) ? ImmutableMap.of("name", name) : Collections.emptyMap();
 
-        response(api.listEvents(query), callback);
+        http.extractConsulResponse(api.listEvents(query), createConsulResponseCallbackWrapper(callback));
+    }
+
+    private ConsulResponseCallback<List<Event>> createConsulResponseCallbackWrapper(EventResponseCallback callback) {
+        return new ConsulResponseCallback<List<Event>>() {
+            @Override
+            public void onComplete(ConsulResponse<List<Event>> response) {
+                callback.onComplete(ImmutableEventResponse.of(response.getResponse(), response.getIndex()));
+            }
+
+            @Override
+            public void onFailure(Throwable throwable) {
+                callback.onFailure(throwable);
+            }
+        };
     }
 
     /**
@@ -192,48 +203,6 @@ public class EventClient extends BaseClient {
     public void listEvents(EventResponseCallback callback) {
         listEvents(null, QueryOptions.BLANK, callback);
     }
-
-    private static void response(Call<List<Event>> call, final EventResponseCallback callback) {
-        call.enqueue(new Callback<List<Event>>() {
-
-            @Override
-            public void onResponse(Call<List<Event>> call, Response<List<Event>> response) {
-                try {
-                    callback.onComplete(eventResponse(response));
-                } catch (Exception ex) {
-                    callback.onFailure(ex);
-                }
-            }
-
-            @Override
-            public void onFailure(Call<List<Event>> call, Throwable t) {
-                callback.onFailure(t);
-            }
-        });
-    }
-
-    private static EventResponse response(Call<List<Event>> call) {
-        Response<List<Event>> response;
-        try {
-            response = call.execute();
-        } catch (IOException e) {
-            throw new ConsulException(e);
-        }
-
-        if(!response.isSuccessful()) {
-            throw new ConsulException(response.code(), response);
-        }
-
-        return eventResponse(response);
-    }
-
-    private static EventResponse eventResponse(Response<List<Event>> response) {
-        String indexHeaderValue = response.headers().get("X-Consul-Index");
-        BigInteger index = indexHeaderValue == null ? BigInteger.ZERO : new BigInteger(indexHeaderValue);
-
-        return ImmutableEventResponse.of(response.body(), index);
-    }
-
     /**
      * Retrofit API interface.
      */

--- a/src/main/java/com/orbitz/consul/EventClient.java
+++ b/src/main/java/com/orbitz/consul/EventClient.java
@@ -6,6 +6,7 @@ import com.orbitz.consul.config.ClientConfig;
 import com.orbitz.consul.model.EventResponse;
 import com.orbitz.consul.model.ImmutableEventResponse;
 import com.orbitz.consul.model.event.Event;
+import com.orbitz.consul.monitoring.ClientEventCallback;
 import com.orbitz.consul.option.EventOptions;
 import com.orbitz.consul.option.QueryOptions;
 import okhttp3.MediaType;
@@ -32,6 +33,8 @@ import static com.orbitz.consul.util.Http.extract;
  */
 public class EventClient extends BaseClient {
 
+    private static String CLIENT_NAME = "event";
+
     private final Api api;
 
     /**
@@ -39,8 +42,8 @@ public class EventClient extends BaseClient {
      *
      * @param retrofit The {@link Retrofit} to build a client from.
      */
-    EventClient(Retrofit retrofit, ClientConfig config) {
-        super(config);
+    EventClient(Retrofit retrofit, ClientConfig config, ClientEventCallback eventCallback) {
+        super(CLIENT_NAME, config, eventCallback);
         this.api = retrofit.create(Api.class);
     }
 

--- a/src/main/java/com/orbitz/consul/HealthClient.java
+++ b/src/main/java/com/orbitz/consul/HealthClient.java
@@ -20,8 +20,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.orbitz.consul.util.Http.extractConsulResponse;
-
 /**
  * HTTP Client for /v1/health/ endpoints.
  */
@@ -66,7 +64,7 @@ public class HealthClient extends BaseClient {
      */
     public ConsulResponse<List<HealthCheck>> getNodeChecks(String node,
                                                            QueryOptions queryOptions) {
-        return extractConsulResponse(api.getNodeChecks(node, queryOptions.toQuery(),
+        return http.extractConsulResponse(api.getNodeChecks(node, queryOptions.toQuery(),
                 queryOptions.getTag(), queryOptions.getNodeMeta()));
     }
 
@@ -93,7 +91,7 @@ public class HealthClient extends BaseClient {
      */
     public ConsulResponse<List<HealthCheck>> getServiceChecks(String service,
                                                               QueryOptions queryOptions) {
-        return extractConsulResponse(api.getServiceChecks(service, queryOptions.toQuery(),
+        return http.extractConsulResponse(api.getServiceChecks(service, queryOptions.toQuery(),
                 queryOptions.getTag(), queryOptions.getNodeMeta()));
     }
 
@@ -111,7 +109,7 @@ public class HealthClient extends BaseClient {
     public void getServiceChecks(String service,
                                  QueryOptions queryOptions,
                                  ConsulResponseCallback<List<HealthCheck>> callback) {
-        extractConsulResponse(api.getServiceChecks(service, queryOptions.toQuery(),
+        http.extractConsulResponse(api.getServiceChecks(service, queryOptions.toQuery(),
                 queryOptions.getTag(), queryOptions.getNodeMeta()), callback);
     }
 
@@ -140,7 +138,7 @@ public class HealthClient extends BaseClient {
      */
     public ConsulResponse<List<HealthCheck>> getChecksByState(State state,
                                                               QueryOptions queryOptions) {
-        return extractConsulResponse(api.getChecksByState(state.getName(), queryOptions.toQuery(),
+        return http.extractConsulResponse(api.getChecksByState(state.getName(), queryOptions.toQuery(),
                 queryOptions.getTag(), queryOptions.getNodeMeta()));
     }
 
@@ -157,7 +155,7 @@ public class HealthClient extends BaseClient {
      */
     public void getChecksByState(State state, QueryOptions queryOptions,
                                  ConsulResponseCallback<List<HealthCheck>> callback) {
-        extractConsulResponse(api.getChecksByState(state.getName(), queryOptions.toQuery(),
+        http.extractConsulResponse(api.getChecksByState(state.getName(), queryOptions.toQuery(),
                 queryOptions.getTag(), queryOptions.getNodeMeta()), callback);
     }
 
@@ -187,7 +185,7 @@ public class HealthClient extends BaseClient {
      */
     public ConsulResponse<List<ServiceHealth>> getHealthyServiceInstances(String service,
                                                                           QueryOptions queryOptions) {
-        return extractConsulResponse(api.getServiceInstances(service,
+        return http.extractConsulResponse(api.getServiceInstances(service,
                 optionsFrom(ImmutableMap.of("passing", "true"), queryOptions.toQuery()),
                 queryOptions.getTag(), queryOptions.getNodeMeta()));
     }
@@ -207,7 +205,7 @@ public class HealthClient extends BaseClient {
      */
     public void getHealthyServiceInstances(String service, QueryOptions queryOptions,
                                            ConsulResponseCallback<List<ServiceHealth>> callback) {
-        extractConsulResponse(api.getServiceInstances(service,
+        http.extractConsulResponse(api.getServiceInstances(service,
                 optionsFrom(ImmutableMap.of("passing", "true"), queryOptions.toQuery()),
                 queryOptions.getTag(), queryOptions.getNodeMeta()), callback);
     }
@@ -237,7 +235,7 @@ public class HealthClient extends BaseClient {
      * {@link com.orbitz.consul.model.health.HealthCheck} objects.
      */
     public ConsulResponse<List<ServiceHealth>> getAllServiceInstances(String service, QueryOptions queryOptions) {
-        return extractConsulResponse(api.getServiceInstances(service, queryOptions.toQuery(),
+        return http.extractConsulResponse(api.getServiceInstances(service, queryOptions.toQuery(),
                 queryOptions.getTag(), queryOptions.getNodeMeta()));
     }
 
@@ -255,7 +253,7 @@ public class HealthClient extends BaseClient {
      */
     public void getAllServiceInstances(String service, QueryOptions queryOptions,
                                        ConsulResponseCallback<List<ServiceHealth>> callback) {
-        extractConsulResponse(api.getServiceInstances(service, queryOptions.toQuery(),
+        http.extractConsulResponse(api.getServiceInstances(service, queryOptions.toQuery(),
                 queryOptions.getTag(), queryOptions.getNodeMeta()), callback);
     }
 

--- a/src/main/java/com/orbitz/consul/HealthClient.java
+++ b/src/main/java/com/orbitz/consul/HealthClient.java
@@ -7,6 +7,7 @@ import com.orbitz.consul.model.ConsulResponse;
 import com.orbitz.consul.model.State;
 import com.orbitz.consul.model.health.HealthCheck;
 import com.orbitz.consul.model.health.ServiceHealth;
+import com.orbitz.consul.monitoring.ClientEventCallback;
 import com.orbitz.consul.option.QueryOptions;
 import retrofit2.Call;
 import retrofit2.Retrofit;
@@ -26,6 +27,8 @@ import static com.orbitz.consul.util.Http.extractConsulResponse;
  */
 public class HealthClient extends BaseClient {
 
+    private static String CLIENT_NAME = "health";
+
     private final Api api;
 
     /**
@@ -33,8 +36,8 @@ public class HealthClient extends BaseClient {
      *
      * @param retrofit The {@link Retrofit} to build a client from.
      */
-    HealthClient(Retrofit retrofit, ClientConfig config) {
-        super(config);
+    HealthClient(Retrofit retrofit, ClientConfig config, ClientEventCallback eventCallback) {
+        super(CLIENT_NAME, config, eventCallback);
         this.api = retrofit.create(Api.class);
     }
 

--- a/src/main/java/com/orbitz/consul/KeyValueClient.java
+++ b/src/main/java/com/orbitz/consul/KeyValueClient.java
@@ -13,6 +13,7 @@ import com.orbitz.consul.model.kv.Operation;
 import com.orbitz.consul.model.kv.TxResponse;
 import com.orbitz.consul.model.kv.Value;
 import com.orbitz.consul.model.session.SessionInfo;
+import com.orbitz.consul.monitoring.ClientEventCallback;
 import com.orbitz.consul.option.ConsistencyMode;
 import com.orbitz.consul.option.DeleteOptions;
 import com.orbitz.consul.option.ImmutablePutOptions;
@@ -50,7 +51,9 @@ import static com.orbitz.consul.util.Strings.trimLeadingSlash;
  */
 public class KeyValueClient extends BaseClient {
 
+    private static String CLIENT_NAME = "keyvalue";
     public static final int NOT_FOUND_404 = 404;
+
     private final Api api;
 
     /**
@@ -58,8 +61,8 @@ public class KeyValueClient extends BaseClient {
      *
      * @param retrofit The {@link Retrofit} to build a client from.
      */
-    KeyValueClient(Retrofit retrofit, ClientConfig config) {
-        super(config);
+    KeyValueClient(Retrofit retrofit, ClientConfig config, ClientEventCallback eventCallback) {
+        super(CLIENT_NAME, config, eventCallback);
         this.api = retrofit.create(Api.class);
     }
 

--- a/src/main/java/com/orbitz/consul/OperatorClient.java
+++ b/src/main/java/com/orbitz/consul/OperatorClient.java
@@ -3,6 +3,7 @@ package com.orbitz.consul;
 import com.google.common.collect.ImmutableMap;
 import com.orbitz.consul.config.ClientConfig;
 import com.orbitz.consul.model.operator.RaftConfiguration;
+import com.orbitz.consul.monitoring.ClientEventCallback;
 import retrofit2.Call;
 import retrofit2.Retrofit;
 import retrofit2.http.DELETE;
@@ -17,10 +18,12 @@ import static com.orbitz.consul.util.Http.handle;
 
 public class OperatorClient extends BaseClient {
 
+    private static String CLIENT_NAME = "operator";
+
     private final Api api;
 
-    OperatorClient(Retrofit retrofit, ClientConfig config) {
-        super(config);
+    OperatorClient(Retrofit retrofit, ClientConfig config, ClientEventCallback eventCallback) {
+        super(CLIENT_NAME, config, eventCallback);
         this.api = retrofit.create(Api.class);
     }
 

--- a/src/main/java/com/orbitz/consul/OperatorClient.java
+++ b/src/main/java/com/orbitz/consul/OperatorClient.java
@@ -13,9 +13,6 @@ import retrofit2.http.QueryMap;
 
 import java.util.Map;
 
-import static com.orbitz.consul.util.Http.extract;
-import static com.orbitz.consul.util.Http.handle;
-
 public class OperatorClient extends BaseClient {
 
     private static String CLIENT_NAME = "operator";
@@ -28,31 +25,31 @@ public class OperatorClient extends BaseClient {
     }
 
     public RaftConfiguration getRaftConfiguration() {
-        return extract(api.getConfiguration(ImmutableMap.of()));
+        return http.extract(api.getConfiguration(ImmutableMap.of()));
     }
 
     public RaftConfiguration getRaftConfiguration(String datacenter) {
-        return extract(api.getConfiguration(ImmutableMap.of("dc", datacenter)));
+        return http.extract(api.getConfiguration(ImmutableMap.of("dc", datacenter)));
     }
 
     public RaftConfiguration getStaleRaftConfiguration(String datacenter) {
-        return extract(api.getConfiguration(ImmutableMap.of(
+        return http.extract(api.getConfiguration(ImmutableMap.of(
             "dc", datacenter, "stale", "true"
         )));
     }
 
     public RaftConfiguration getStaleRaftConfiguration() {
-        return extract(api.getConfiguration(ImmutableMap.of(
+        return http.extract(api.getConfiguration(ImmutableMap.of(
                 "stale", "true"
         )));
     }
 
     public void deletePeer(String address) {
-        handle(api.deletePeer(address, ImmutableMap.of()));
+        http.handle(api.deletePeer(address, ImmutableMap.of()));
     }
 
     public void deletePeer(String address, String datacenter) {
-        handle(api.deletePeer(address, ImmutableMap.of("dc", datacenter)));
+        http.handle(api.deletePeer(address, ImmutableMap.of("dc", datacenter)));
     }
 
     interface Api {

--- a/src/main/java/com/orbitz/consul/PreparedQueryClient.java
+++ b/src/main/java/com/orbitz/consul/PreparedQueryClient.java
@@ -18,9 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.orbitz.consul.util.Http.extract;
-import static com.orbitz.consul.util.Http.extractBasicResponse;
-
 public class PreparedQueryClient extends BaseClient {
 
     private static String CLIENT_NAME = "preparedquery";
@@ -59,7 +56,7 @@ public class PreparedQueryClient extends BaseClient {
      * @return The ID of the created query.
      */
     public String createPreparedQuery(PreparedQuery preparedQuery, final String dc) {
-        return extract(api.createPreparedQuery(preparedQuery, dcQuery(dc))).getId();
+        return http.extract(api.createPreparedQuery(preparedQuery, dcQuery(dc))).getId();
     }
 
     private Map<String, String> dcQuery(String dc) {
@@ -86,7 +83,7 @@ public class PreparedQueryClient extends BaseClient {
      * @return The list of prepared queries.
      */
     public List<StoredQuery> getPreparedQueries(final String dc) {
-        return extract(api.getPreparedQueries(dcQuery(dc)));
+        return http.extract(api.getPreparedQueries(dcQuery(dc)));
     }
 
     /**
@@ -111,7 +108,7 @@ public class PreparedQueryClient extends BaseClient {
      * @return The store prepared query.
      */
     public Optional<StoredQuery> getPreparedQuery(String id, final String dc) {
-        List<StoredQuery> result = extract(api.getPreparedQuery(id, dcQuery(dc)));
+        List<StoredQuery> result = http.extract(api.getPreparedQuery(id, dcQuery(dc)));
 
         return result.isEmpty() ? Optional.empty() : Optional.of(result.get(0));
     }
@@ -123,7 +120,7 @@ public class PreparedQueryClient extends BaseClient {
      * @return A {@link QueryResults} object containing service instances.
      */
     public QueryResults execute(String nameOrId) {
-        return extract(api.execute(nameOrId, Collections.emptyMap()));
+        return http.extract(api.execute(nameOrId, Collections.emptyMap()));
     }
 
     /**
@@ -134,7 +131,7 @@ public class PreparedQueryClient extends BaseClient {
      * @param callback Basic callback for the response.
      */
     public void execute(String nameOrId, QueryOptions options, final Callback<QueryResults> callback) {
-        extractBasicResponse(api.execute(nameOrId, options.toQuery()), callback);
+        http.extractBasicResponse(api.execute(nameOrId, options.toQuery()), callback);
     }
 
     /**

--- a/src/main/java/com/orbitz/consul/PreparedQueryClient.java
+++ b/src/main/java/com/orbitz/consul/PreparedQueryClient.java
@@ -7,6 +7,7 @@ import com.orbitz.consul.model.query.PreparedQuery;
 import com.orbitz.consul.model.query.QueryId;
 import com.orbitz.consul.model.query.QueryResults;
 import com.orbitz.consul.model.query.StoredQuery;
+import com.orbitz.consul.monitoring.ClientEventCallback;
 import com.orbitz.consul.option.QueryOptions;
 import retrofit2.Call;
 import retrofit2.Retrofit;
@@ -22,6 +23,8 @@ import static com.orbitz.consul.util.Http.extractBasicResponse;
 
 public class PreparedQueryClient extends BaseClient {
 
+    private static String CLIENT_NAME = "preparedquery";
+
     private final Api api;
 
     /**
@@ -29,8 +32,8 @@ public class PreparedQueryClient extends BaseClient {
      *
      * @param retrofit The {@link Retrofit} to build a client from.
      */
-    PreparedQueryClient(Retrofit retrofit, ClientConfig config) {
-        super(config);
+    PreparedQueryClient(Retrofit retrofit, ClientConfig config, ClientEventCallback eventCallback) {
+        super(CLIENT_NAME, config, eventCallback);
         this.api = retrofit.create(Api.class);
     }
 

--- a/src/main/java/com/orbitz/consul/SessionClient.java
+++ b/src/main/java/com/orbitz/consul/SessionClient.java
@@ -15,9 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.orbitz.consul.util.Http.extract;
-import static com.orbitz.consul.util.Http.handle;
-
 /**
  * HTTP Client for /v1/session/ endpoints.
  *
@@ -61,7 +58,7 @@ public class SessionClient extends BaseClient {
      * @return Response containing the session ID.
      */
     public SessionCreatedResponse createSession(final Session value, final String dc) {
-        return extract(api.createSession(value, dcQuery(dc)));
+        return http.extract(api.createSession(value, dcQuery(dc)));
     }
 
     private Map<String, String> dcQuery(String dc) {
@@ -80,7 +77,7 @@ public class SessionClient extends BaseClient {
      * @return The {@link SessionInfo} object for the renewed session.
      */
     public Optional<SessionInfo> renewSession(final String dc, final String sessionId) {
-        List<SessionInfo> sessionInfo = extract(api.renewSession(sessionId,
+        List<SessionInfo> sessionInfo = http.extract(api.renewSession(sessionId,
                 ImmutableMap.of(), dcQuery(dc)));
 
         return sessionInfo == null || sessionInfo.isEmpty() ? Optional.empty() :
@@ -107,7 +104,7 @@ public class SessionClient extends BaseClient {
      * @param dc        The data center.
      */
     public void destroySession(final String sessionId, final String dc) {
-        handle(api.destroySession(sessionId, dcQuery(dc)));
+        http.handle(api.destroySession(sessionId, dcQuery(dc)));
     }
 
     /**
@@ -132,7 +129,7 @@ public class SessionClient extends BaseClient {
      * @return {@link SessionInfo}.
      */
     public Optional<SessionInfo> getSessionInfo(final String sessionId, final String dc) {
-        List<SessionInfo> sessionInfo = extract(api.getSessionInfo(sessionId, dcQuery(dc)));
+        List<SessionInfo> sessionInfo = http.extract(api.getSessionInfo(sessionId, dcQuery(dc)));
 
         return sessionInfo == null || sessionInfo.isEmpty() ? Optional.empty() :
                 Optional.of(sessionInfo.get(0));
@@ -147,7 +144,7 @@ public class SessionClient extends BaseClient {
      * @return A list of available sessions.
      */
     public List<SessionInfo> listSessions(final String dc) {
-        return extract(api.listSessions(dcQuery(dc)));
+        return http.extract(api.listSessions(dcQuery(dc)));
     }
 
     /**

--- a/src/main/java/com/orbitz/consul/SessionClient.java
+++ b/src/main/java/com/orbitz/consul/SessionClient.java
@@ -5,6 +5,7 @@ import com.orbitz.consul.config.ClientConfig;
 import com.orbitz.consul.model.session.Session;
 import com.orbitz.consul.model.session.SessionCreatedResponse;
 import com.orbitz.consul.model.session.SessionInfo;
+import com.orbitz.consul.monitoring.ClientEventCallback;
 import retrofit2.Call;
 import retrofit2.Retrofit;
 import retrofit2.http.*;
@@ -24,6 +25,8 @@ import static com.orbitz.consul.util.Http.handle;
  */
 public class SessionClient extends BaseClient {
 
+    private static String CLIENT_NAME = "session";
+
     private final Api api;
 
     /**
@@ -31,8 +34,8 @@ public class SessionClient extends BaseClient {
      *
      * @param retrofit The {@link Retrofit} to build a client from.
      */
-    SessionClient(Retrofit retrofit, ClientConfig config) {
-        super(config);
+    SessionClient(Retrofit retrofit, ClientConfig config, ClientEventCallback eventCallback) {
+        super(CLIENT_NAME, config, eventCallback);
         this.api = retrofit.create(Api.class);
     }
 

--- a/src/main/java/com/orbitz/consul/StatusClient.java
+++ b/src/main/java/com/orbitz/consul/StatusClient.java
@@ -1,6 +1,7 @@
 package com.orbitz.consul;
 
 import com.orbitz.consul.config.ClientConfig;
+import com.orbitz.consul.monitoring.ClientEventCallback;
 import retrofit2.Call;
 import retrofit2.Retrofit;
 import retrofit2.http.GET;
@@ -11,6 +12,8 @@ import static com.orbitz.consul.util.Http.extract;
 
 public class StatusClient extends BaseClient {
 
+    private static String CLIENT_NAME = "status";
+
     private final Api api;
 
     /**
@@ -18,8 +21,8 @@ public class StatusClient extends BaseClient {
      *
      * @param retrofit The {@link Retrofit} to build a client from.
      */
-    StatusClient(Retrofit retrofit, ClientConfig config) {
-        super(config);
+    StatusClient(Retrofit retrofit, ClientConfig config, ClientEventCallback eventCallback) {
+        super(CLIENT_NAME, config, eventCallback);
         this.api = retrofit.create(Api.class);
     }
 

--- a/src/main/java/com/orbitz/consul/StatusClient.java
+++ b/src/main/java/com/orbitz/consul/StatusClient.java
@@ -8,8 +8,6 @@ import retrofit2.http.GET;
 
 import java.util.List;
 
-import static com.orbitz.consul.util.Http.extract;
-
 public class StatusClient extends BaseClient {
 
     private static String CLIENT_NAME = "status";
@@ -34,7 +32,7 @@ public class StatusClient extends BaseClient {
      * @return The host/port of the leader.
      */
     public String getLeader() {
-        return extract(api.getLeader()).replace("\"", "").trim();
+        return http.extract(api.getLeader()).replace("\"", "").trim();
     }
 
     /**
@@ -45,7 +43,7 @@ public class StatusClient extends BaseClient {
      * @return List of host/ports for raft peers.
      */
     public List<String> getPeers() {
-        return extract(api.getPeers());
+        return http.extract(api.getPeers());
     }
 
     /**

--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -8,6 +8,7 @@ import com.orbitz.consul.ConsulException;
 import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.config.CacheConfig;
 import com.orbitz.consul.model.ConsulResponse;
+import com.orbitz.consul.monitoring.ClientEventHandler;
 import com.orbitz.consul.option.ImmutableQueryOptions;
 import com.orbitz.consul.option.QueryOptions;
 import org.slf4j.Logger;
@@ -60,14 +61,17 @@ public class ConsulCache<K, V> implements AutoCloseable {
     private final Function<V, K> keyConversion;
     private final CallbackConsumer<V> callBackConsumer;
     private final ConsulResponseCallback<List<V>> responseCallback;
+    private final ClientEventHandler eventHandler;
 
     ConsulCache(
             Function<V, K> keyConversion,
             CallbackConsumer<V> callbackConsumer,
-            CacheConfig cacheConfig) {
+            CacheConfig cacheConfig,
+            ClientEventHandler eventHandler) {
 
         this.keyConversion = keyConversion;
         this.callBackConsumer = callbackConsumer;
+        this.eventHandler = eventHandler;
 
         this.responseCallback = new ConsulResponseCallback<List<V>>() {
             @Override

--- a/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
+++ b/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
@@ -4,6 +4,7 @@ import com.google.common.primitives.Ints;
 import com.orbitz.consul.HealthClient;
 import com.orbitz.consul.config.CacheConfig;
 import com.orbitz.consul.model.health.HealthCheck;
+import com.orbitz.consul.monitoring.ClientEventHandler;
 import com.orbitz.consul.option.QueryOptions;
 
 import java.util.function.Function;
@@ -12,8 +13,9 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
 
     private HealthCheckCache(Function<HealthCheck, String> keyConversion,
                              CallbackConsumer<HealthCheck> callbackConsumer,
-                             CacheConfig cacheConfig) {
-        super(keyConversion, callbackConsumer, cacheConfig);
+                             CacheConfig cacheConfig,
+                             ClientEventHandler eventHandler) {
+        super(keyConversion, callbackConsumer, cacheConfig, eventHandler);
     }
 
     /**
@@ -36,7 +38,10 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
             QueryOptions params = watchParams(index, watchSeconds, queryOptions);
             healthClient.getChecksByState(state, params, callback);
         };
-        return new HealthCheckCache(keyExtractor, callbackConsumer, healthClient.getConfig().getCacheConfig());
+        return new HealthCheckCache(keyExtractor,
+                callbackConsumer,
+                healthClient.getConfig().getCacheConfig(),
+                healthClient.getEventHandler());
     }
 
     public static HealthCheckCache newCache(

--- a/src/main/java/com/orbitz/consul/cache/KVCache.java
+++ b/src/main/java/com/orbitz/consul/cache/KVCache.java
@@ -6,6 +6,7 @@ import com.google.common.primitives.Ints;
 import com.orbitz.consul.KeyValueClient;
 import com.orbitz.consul.config.CacheConfig;
 import com.orbitz.consul.model.kv.Value;
+import com.orbitz.consul.monitoring.ClientEventHandler;
 import com.orbitz.consul.option.QueryOptions;
 
 import java.util.function.Function;
@@ -14,8 +15,9 @@ public class KVCache extends ConsulCache<String, Value> {
 
     private KVCache(Function<Value, String> keyConversion,
                     ConsulCache.CallbackConsumer<Value> callbackConsumer,
-                    CacheConfig cacheConfig) {
-        super(keyConversion, callbackConsumer, cacheConfig);
+                    CacheConfig cacheConfig,
+                    ClientEventHandler eventHandler) {
+        super(keyConversion, callbackConsumer, cacheConfig, eventHandler);
     }
 
     @VisibleForTesting
@@ -50,7 +52,10 @@ public class KVCache extends ConsulCache<String, Value> {
             kvClient.getValues(keyPath, params, callback);
         };
 
-        return new KVCache(keyExtractor, callbackConsumer, kvClient.getConfig().getCacheConfig());
+        return new KVCache(keyExtractor,
+                callbackConsumer,
+                kvClient.getConfig().getCacheConfig(),
+                kvClient.getEventHandler());
     }
 
     @VisibleForTesting

--- a/src/main/java/com/orbitz/consul/cache/NodesCatalogCache.java
+++ b/src/main/java/com/orbitz/consul/cache/NodesCatalogCache.java
@@ -4,6 +4,7 @@ import com.google.common.primitives.Ints;
 import com.orbitz.consul.CatalogClient;
 import com.orbitz.consul.config.CacheConfig;
 import com.orbitz.consul.model.health.Node;
+import com.orbitz.consul.monitoring.ClientEventHandler;
 import com.orbitz.consul.option.QueryOptions;
 
 import java.util.function.Function;
@@ -12,8 +13,9 @@ public class NodesCatalogCache extends ConsulCache<String, Node> {
 
     private NodesCatalogCache(Function<Node, String> keyConversion,
                               CallbackConsumer<Node> callbackConsumer,
-                              CacheConfig cacheConfig) {
-        super(keyConversion, callbackConsumer, cacheConfig);
+                              CacheConfig cacheConfig,
+                              ClientEventHandler eventHandler) {
+        super(keyConversion, callbackConsumer, cacheConfig, eventHandler);
     }
 
     public static NodesCatalogCache newCache(
@@ -24,7 +26,10 @@ public class NodesCatalogCache extends ConsulCache<String, Node> {
         final CallbackConsumer<Node> callbackConsumer = (index, callback) ->
                 catalogClient.getNodes(watchParams(index, watchSeconds, queryOptions), callback);
 
-        return new NodesCatalogCache(Node::getNode, callbackConsumer, catalogClient.getConfig().getCacheConfig());
+        return new NodesCatalogCache(Node::getNode,
+                callbackConsumer,
+                catalogClient.getConfig().getCacheConfig(),
+                catalogClient.getEventHandler());
     }
 
     public static NodesCatalogCache newCache(final CatalogClient catalogClient) {

--- a/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
@@ -5,6 +5,7 @@ import com.google.common.primitives.Ints;
 import com.orbitz.consul.HealthClient;
 import com.orbitz.consul.config.CacheConfig;
 import com.orbitz.consul.model.health.ServiceHealth;
+import com.orbitz.consul.monitoring.ClientEventHandler;
 import com.orbitz.consul.option.QueryOptions;
 
 import java.util.function.Function;
@@ -13,8 +14,9 @@ public class ServiceHealthCache extends ConsulCache<ServiceHealthKey, ServiceHea
 
     private ServiceHealthCache(Function<ServiceHealth, ServiceHealthKey> keyConversion,
                                CallbackConsumer<ServiceHealth> callbackConsumer,
-                               CacheConfig cacheConfig) {
-        super(keyConversion, callbackConsumer, cacheConfig);
+                               CacheConfig cacheConfig,
+                               ClientEventHandler eventHandler) {
+        super(keyConversion, callbackConsumer, cacheConfig, eventHandler);
     }
 
     /**
@@ -44,7 +46,10 @@ public class ServiceHealthCache extends ConsulCache<ServiceHealthKey, ServiceHea
             }
         };
 
-        return new ServiceHealthCache(keyExtractor, callbackConsumer, healthClient.getConfig().getCacheConfig());
+        return new ServiceHealthCache(keyExtractor,
+                callbackConsumer,
+                healthClient.getConfig().getCacheConfig(),
+                healthClient.getEventHandler());
     }
 
     public static ServiceHealthCache newCache(

--- a/src/main/java/com/orbitz/consul/monitoring/ClientEventCallback.java
+++ b/src/main/java/com/orbitz/consul/monitoring/ClientEventCallback.java
@@ -1,5 +1,7 @@
 package com.orbitz.consul.monitoring;
 
+import java.time.Duration;
+
 public interface ClientEventCallback {
 
     default void onHttpRequestSuccess(String clientName, String method, String queryString) { }
@@ -7,4 +9,12 @@ public interface ClientEventCallback {
     default void onHttpRequestFailure(String clientName, String method, String queryString, Throwable throwable) { }
 
     default void onHttpRequestInvalid(String clientName, String method, String queryString, Throwable throwable) { }
+
+    default void onCacheStart(String clientName) { }
+
+    default void onCacheStop(String clientName) { }
+
+    default void onCachePollingError(String clientName, Throwable throwable) { }
+
+    default void onCachePollingSuccess(String clientName, boolean withNotification, Duration duration) { }
 }

--- a/src/main/java/com/orbitz/consul/monitoring/ClientEventCallback.java
+++ b/src/main/java/com/orbitz/consul/monitoring/ClientEventCallback.java
@@ -1,0 +1,10 @@
+package com.orbitz.consul.monitoring;
+
+public interface ClientEventCallback {
+
+    default void onHttpRequestSuccess(String clientName, String method, String queryString) { }
+
+    default void onHttpRequestFailure(String clientName, String method, String queryString, Throwable throwable) { }
+
+    default void onHttpRequestInvalid(String clientName, String method, String queryString, Throwable throwable) { }
+}

--- a/src/main/java/com/orbitz/consul/monitoring/ClientEventHandler.java
+++ b/src/main/java/com/orbitz/consul/monitoring/ClientEventHandler.java
@@ -1,0 +1,36 @@
+package com.orbitz.consul.monitoring;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import okhttp3.Request;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class ClientEventHandler {
+
+    private static final ScheduledExecutorService EVENT_EXECUTOR = Executors.newSingleThreadScheduledExecutor(
+            new ThreadFactoryBuilder().setNameFormat("event-executor-%s").setDaemon(true).build());
+
+    private final String clientName;
+    private final ClientEventCallback callback;
+
+    public ClientEventHandler(String clientName, ClientEventCallback callback) {
+        this.clientName = clientName;
+        this.callback = callback;
+    }
+
+    public void httpRequestSuccess(Request request) {
+        EVENT_EXECUTOR.submit(() -> callback.onHttpRequestSuccess(clientName, request.method(), request.url().query()));
+    }
+
+    public void httpRequestInvalid(Request request, Throwable throwable) {
+        EVENT_EXECUTOR.submit(() ->
+                callback.onHttpRequestInvalid(clientName, request.method(), request.url().query(), throwable));
+    }
+
+    public void httpRequestFailure(Request request, Throwable throwable) {
+        EVENT_EXECUTOR.submit(() ->
+                callback.onHttpRequestFailure(clientName, request.method(), request.url().query(), throwable));
+    }
+
+}

--- a/src/main/java/com/orbitz/consul/monitoring/ClientEventHandler.java
+++ b/src/main/java/com/orbitz/consul/monitoring/ClientEventHandler.java
@@ -3,6 +3,7 @@ package com.orbitz.consul.monitoring;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import okhttp3.Request;
 
+import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -31,6 +32,22 @@ public class ClientEventHandler {
     public void httpRequestFailure(Request request, Throwable throwable) {
         EVENT_EXECUTOR.submit(() ->
                 callback.onHttpRequestFailure(clientName, request.method(), request.url().query(), throwable));
+    }
+
+    public void cacheStart() {
+        EVENT_EXECUTOR.submit(() -> callback.onCacheStart(clientName));
+    }
+
+    public void cacheStop() {
+        EVENT_EXECUTOR.submit(() -> callback.onCacheStop(clientName));
+    }
+
+    public void cachePollingError(Throwable throwable) {
+        EVENT_EXECUTOR.submit(() -> callback.onCachePollingError(clientName, throwable));
+    }
+
+    public void cachePollingSuccess(boolean withNotification, Duration duration) {
+        EVENT_EXECUTOR.submit(() -> callback.onCachePollingSuccess(clientName, withNotification, duration));
     }
 
 }

--- a/src/main/java/com/orbitz/consul/util/Http.java
+++ b/src/main/java/com/orbitz/consul/util/Http.java
@@ -88,7 +88,7 @@ public class Http {
                 eventHandler.httpRequestFailure(call.request(), t);
                 callback.onFailure(t);
             }
-        });
+        };
     }
 
     public <T> void extractBasicResponse(Call<T> call, final Callback<T> callback,
@@ -110,7 +110,8 @@ public class Http {
         };
     }
 
-    private static <T> ConsulResponse<T> consulResponse(Response<T> response) {
+    @VisibleForTesting
+    static <T> ConsulResponse<T> consulResponse(Response<T> response) {
         Headers headers = response.headers();
         String indexHeaderValue = headers.get("X-Consul-Index");
         String lastContactHeaderValue = headers.get("X-Consul-Lastcontact");

--- a/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
@@ -5,6 +5,7 @@ import com.orbitz.consul.BaseIntegrationTest;
 import com.orbitz.consul.config.CacheConfig;
 import com.orbitz.consul.model.ConsulResponse;
 import com.orbitz.consul.model.kv.Value;
+import com.orbitz.consul.monitoring.ClientEventHandler;
 import com.orbitz.consul.option.ConsistencyMode;
 import com.orbitz.consul.option.ImmutableQueryOptions;
 import com.orbitz.consul.option.QueryOptions;
@@ -30,7 +31,8 @@ public class ConsulCacheTest extends BaseIntegrationTest {
         final Function<Value, String> keyExtractor = input -> "SAME_KEY";
         final List<Value> response = Arrays.asList(mock(Value.class), mock(Value.class));
         CacheConfig cacheConfig = mock(CacheConfig.class);
-        final ConsulCache<String, Value> consulCache = new ConsulCache<>(keyExtractor, null, cacheConfig);
+        ClientEventHandler eventHandler = mock(ClientEventHandler.class);
+        final ConsulCache<String, Value> consulCache = new ConsulCache<>(keyExtractor, null, cacheConfig, eventHandler);
         final ConsulResponse<List<Value>> consulResponse = new ConsulResponse<>(response, 0, false, BigInteger.ONE);
         final ImmutableMap<String, Value> map = consulCache.convertToMap(consulResponse);
         assertNotNull(map);

--- a/src/test/java/com/orbitz/consul/util/HttpTest.java
+++ b/src/test/java/com/orbitz/consul/util/HttpTest.java
@@ -1,0 +1,306 @@
+package com.orbitz.consul.util;
+
+import com.orbitz.consul.ConsulException;
+import com.orbitz.consul.async.ConsulResponseCallback;
+import com.orbitz.consul.model.ConsulResponse;
+import com.orbitz.consul.monitoring.ClientEventHandler;
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.ResponseBody;
+import org.junit.Before;
+import org.junit.Test;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class HttpTest {
+
+    private ClientEventHandler clientEventHandler;
+    private Http http;
+
+    @Before
+    public void setUp() {
+        clientEventHandler = mock(ClientEventHandler.class);
+        http = new Http(clientEventHandler);
+    }
+
+    private <T> Function<Call<T>, T> createExtractWrapper() {
+        return (call) -> http.extract(call);
+    }
+
+    private Function<Call<Void>, Void> createHandleWrapper() {
+        return call -> {
+            http.handle(call);
+            return null;
+        };
+    }
+
+    private <T> Function<Call<T>, ConsulResponse<T>> createExtractConsulResponseWrapper() {
+        return (call) -> http.extractConsulResponse(call);
+    }
+
+    @Test
+    public void extractingBodyShouldSucceedWhenRequestSucceed() throws IOException {
+        String expectedBody = "success";
+        Response<String> response = Response.success(expectedBody);
+        Call<String> call = mock(Call.class);
+        doReturn(response).when(call).execute();
+        String body = http.extract(call);
+        assertEquals(expectedBody, body);
+    }
+
+    @Test
+    public void handlingRequestShouldNotThrowWhenRequestSucceed() throws IOException {
+        String expectedBody = "success";
+        Response<String> response = Response.success(expectedBody);
+        Call<Void> call = mock(Call.class);
+        doReturn(response).when(call).execute();
+        http.handle(call);
+    }
+
+    @Test
+    public void extractingConsulResponseShouldSucceedWhenRequestSucceed() throws IOException {
+        String expectedBody = "success";
+        Response<String> response = Response.success(expectedBody);
+        Call<String> call = mock(Call.class);
+        doReturn(response).when(call).execute();
+        ConsulResponse<String> consulResponse = http.extractConsulResponse(call);
+        assertEquals(expectedBody, consulResponse.getResponse());
+    }
+
+    @Test(expected = ConsulException.class)
+    public void extractingBodyShouldThrowWhenRequestFailed() throws IOException {
+        checkForFailedRequest(createExtractWrapper());
+    }
+
+    @Test(expected = ConsulException.class)
+    public void handlingRequestShouldThrowWhenRequestFailed() throws IOException {
+        checkForFailedRequest(createHandleWrapper());
+    }
+
+    @Test(expected = ConsulException.class)
+    public void extractingConsulResponseShouldThrowWhenRequestFailed() throws IOException {
+        checkForFailedRequest(createExtractConsulResponseWrapper());
+    }
+
+    private <U, V> void checkForFailedRequest(Function<Call<U>, V> httpCall) throws IOException {
+        Call<U> call = mock(Call.class);
+        doThrow(new IOException("failure")).when(call).execute();
+        httpCall.apply(call);
+    }
+
+    @Test(expected = ConsulException.class)
+    public void extractingBodyShouldThrowWhenRequestIsInvalid() throws IOException {
+        checkForInvalidRequest(createExtractWrapper());
+    }
+
+    @Test(expected = ConsulException.class)
+    public void handlingRequestShouldThrowWhenRequestIsInvalid() throws IOException {
+        checkForInvalidRequest(createHandleWrapper());
+    }
+
+    @Test(expected = ConsulException.class)
+    public void extractingConsulResponseShouldThrowWhenRequestIsInvalid() throws IOException {
+        checkForInvalidRequest(createExtractConsulResponseWrapper());
+    }
+
+    private <U, V> void checkForInvalidRequest(Function<Call<U>, V> httpCall) throws IOException {
+        Response<String> response = Response.error(400, ResponseBody.create(MediaType.parse(""), "failure"));
+        Call<U> call = mock(Call.class);
+        doReturn(response).when(call).execute();
+        httpCall.apply(call);
+    }
+
+    @Test
+    public void extractingBodyShouldSendSuccessEventWhenRequestSucceed() throws IOException {
+        checkSuccessEventIsSentWhenRequestSucceed(createExtractWrapper());
+    }
+
+    @Test
+    public void handlingRequestShouldSendSuccessEventWhenRequestSucceed() throws IOException {
+        checkSuccessEventIsSentWhenRequestSucceed(createHandleWrapper());
+    }
+
+    @Test
+    public void extractingConsulResponseShouldSendSuccessEventWhenRequestSucceed() throws IOException {
+        checkSuccessEventIsSentWhenRequestSucceed(createExtractConsulResponseWrapper());
+    }
+
+    private <U, V> void checkSuccessEventIsSentWhenRequestSucceed(Function<Call<U>, V> httpCall) throws IOException {
+        String expectedBody = "success";
+        Response<String> response = Response.success(expectedBody);
+        Call<U> call = mock(Call.class);
+        doReturn(response).when(call).execute();
+        httpCall.apply(call);
+        verify(clientEventHandler, only()).httpRequestSuccess(any(Request.class));
+    }
+
+    @Test
+    public void extractingBodyShouldSendFailureEventWhenRequestFailed() throws IOException {
+        checkFailureEventIsSentWhenRequestFailed(createExtractWrapper());
+    }
+
+    @Test
+    public void handlingRequestShouldSendFailureEventWhenRequestFailed() throws IOException {
+        checkFailureEventIsSentWhenRequestFailed(createHandleWrapper());
+    }
+
+    @Test
+    public void extractingConsulResponseShouldSendFailureEventWhenRequestFailed() throws IOException {
+        checkFailureEventIsSentWhenRequestFailed(createExtractConsulResponseWrapper());
+    }
+
+    private <U, V> void checkFailureEventIsSentWhenRequestFailed(Function<Call<U>, V> httpCall) throws IOException {
+        Call<U> call = mock(Call.class);
+        doThrow(new IOException("failure")).when(call).execute();
+        try {
+            httpCall.apply(call);
+        } catch (ConsulException e) {
+            //ignore
+        }
+        verify(clientEventHandler, only()).httpRequestFailure(any(Request.class), any(Throwable.class));
+    }
+
+    @Test
+    public void extractingBodyShouldSendInvalidEventWhenRequestIsInvalid() throws IOException {
+        checkInvalidEventIsSentWhenRequestIsInvalid(createExtractWrapper());
+    }
+
+    @Test
+    public void handlingRequestShouldSendInvalidEventWhenRequestIsInvalid() throws IOException {
+        checkInvalidEventIsSentWhenRequestIsInvalid(createHandleWrapper());
+    }
+
+    @Test
+    public void extractingConsulResponseShouldSendInvalidEventWhenRequestIsInvalid() throws IOException {
+        checkInvalidEventIsSentWhenRequestIsInvalid(createExtractConsulResponseWrapper());
+    }
+
+    private <U, V> void checkInvalidEventIsSentWhenRequestIsInvalid(Function<Call<U>, V> httpCall) throws IOException {
+        Response<String> response = Response.error(400, ResponseBody.create(MediaType.parse(""), "failure"));
+        Call<U> call = mock(Call.class);
+        doReturn(response).when(call).execute();
+        try {
+            httpCall.apply(call);
+        } catch (ConsulException e) {
+            //ignore
+        }
+        verify(clientEventHandler, only()).httpRequestInvalid(any(Request.class), any(Throwable.class));
+    }
+
+    @Test
+    public void extractingConsulResponseAsyncShouldSucceedWhenRequestSucceed() throws IOException, InterruptedException {
+        AtomicReference<ConsulResponse<String>> result = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        final ConsulResponseCallback<String> callback = new ConsulResponseCallback<String>() {
+            @Override
+            public void onComplete(ConsulResponse<String> consulResponse) {
+                result.set(consulResponse);
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Throwable throwable) { }
+        };
+
+        Call<String> call = mock(Call.class);
+        Request request = new Request.Builder().url("http://localhost:8500/this/endpoint").build();
+        when(call.request()).thenReturn(request);
+        Callback<String> callCallback = http.createCallback(call, callback);
+
+        String expectedBody = "success";
+        Response<String> response = Response.success(expectedBody);
+        callCallback.onResponse(call, response);
+
+        latch.await(1, TimeUnit.SECONDS);
+        assertEquals(expectedBody, result.get().getResponse());
+        verify(clientEventHandler, only()).httpRequestSuccess(any(Request.class));
+    }
+
+    @Test
+    public void extractingConsulResponseAsyncShouldFailWhenRequestIsInvalid() throws IOException, InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        final ConsulResponseCallback<String> callback = new ConsulResponseCallback<String>() {
+            @Override
+            public void onComplete(ConsulResponse<String> consulResponse) {}
+
+            @Override
+            public void onFailure(Throwable throwable) {
+                latch.countDown();
+            }
+        };
+
+        Call<String> call = mock(Call.class);
+        Request request = new Request.Builder().url("http://localhost:8500/this/endpoint").build();
+        when(call.request()).thenReturn(request);
+        Callback<String> callCallback = http.createCallback(call, callback);
+
+        Response<String> response = Response.error(400, ResponseBody.create(MediaType.parse(""), "failure"));
+        callCallback.onResponse(call, response);
+
+        latch.await(1, TimeUnit.SECONDS);
+        verify(clientEventHandler, only()).httpRequestInvalid(any(Request.class), any(Throwable.class));
+    }
+
+    @Test
+    public void extractingConsulResponseAsyncShouldFailWhenRequestFailed() throws IOException, InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        final ConsulResponseCallback<String> callback = new ConsulResponseCallback<String>() {
+            @Override
+            public void onComplete(ConsulResponse<String> consulResponse) {}
+
+            @Override
+            public void onFailure(Throwable throwable) {
+                latch.countDown();
+            }
+        };
+
+        Call<String> call = mock(Call.class);
+        Callback<String> callCallback = http.createCallback(call, callback);
+
+        callCallback.onFailure(call, new RuntimeException("the request failed"));
+
+        latch.await(1, TimeUnit.SECONDS);
+        verify(clientEventHandler, only()).httpRequestFailure(any(Request.class), any(Throwable.class));
+    }
+
+    @Test
+    public void consulResponseShouldHaveResponseAndDefaultValuesIfNoHeader() {
+        Response<String> response = Response.success("success");
+        ConsulResponse<String> consulResponse = Http.consulResponse(response);
+        ConsulResponse<String> expectedConsulResponse = new ConsulResponse<>("success", 0, false, BigInteger.ZERO);
+        assertEquals(expectedConsulResponse, consulResponse);
+    }
+
+    @Test
+    public void consulResponseShouldHaveIndexIfPresentInHeader() {
+        Response<String> response = Response.success("", Headers.of("X-Consul-Index", "10"));
+        ConsulResponse<String> consulResponse = Http.consulResponse(response);
+        assertEquals(BigInteger.TEN, consulResponse.getIndex());
+    }
+
+    @Test
+    public void consulResponseShouldHaveLastContactIfPresentInHeader() {
+        Response<String> response = Response.success("", Headers.of("X-Consul-Lastcontact", "2"));
+        ConsulResponse<String> consulResponse = Http.consulResponse(response);
+        assertEquals(2L, consulResponse.getLastContact());
+    }
+
+    @Test
+    public void consulResponseShouldHaveKnownLeaderIfPresentInHeader() {
+        Response<String> response = Response.success("", Headers.of("X-Consul-Knownleader", "true"));
+        ConsulResponse<String> consulResponse = Http.consulResponse(response);
+        assertEquals(true, consulResponse.isKnownLeader());
+    }
+}


### PR DESCRIPTION
Monitor http request and cache events:
 - http requests failure, success or invalid response
 - cache start/stop
 - cache polling request (success/failure) with/without notification

Users will be able to implement methods of the callback (only those interesting them) to add custom monitoring (logs, metrics, ...).