### PR TITLE
Enable setting cache refresh error log as Warning

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -141,8 +141,14 @@ public class ConsulCache<K, V> implements AutoCloseable {
                 }
                 eventHandler.cachePollingError(throwable);
 
-                LOGGER.error(String.format("Error getting response from consul. will retry in %d %s",
-                        cacheConfig.getBackOffDelay().toMillis(), TimeUnit.MILLISECONDS), throwable);
+                String message = String.format("Error getting response from consul. will retry in %d %s",
+                        cacheConfig.getBackOffDelay().toMillis(), TimeUnit.MILLISECONDS);
+
+                if (cacheConfig.isRefreshErrorLoggedAsWarning()) {
+                    LOGGER.warn(message, throwable);
+                } else {
+                    LOGGER.error(message, throwable);
+                }
 
                 executorService.schedule(ConsulCache.this::runCallback,
                         cacheConfig.getBackOffDelay().toMillis(), TimeUnit.MILLISECONDS);

--- a/src/main/java/com/orbitz/consul/config/CacheConfig.java
+++ b/src/main/java/com/orbitz/consul/config/CacheConfig.java
@@ -2,11 +2,7 @@ package com.orbitz.consul.config;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-
 import java.time.Duration;
-import java.util.Optional;
-
-import static java.util.Optional.empty;
 
 public class CacheConfig {
 
@@ -20,18 +16,23 @@ public class CacheConfig {
     static final boolean DEFAULT_TIMEOUT_AUTO_ADJUSTMENT_ENABLED = true;
     @VisibleForTesting
     static final Duration DEFAULT_TIMEOUT_AUTO_ADJUSTMENT_MARGIN = Duration.ofSeconds(2);
+    @VisibleForTesting
+    static final boolean DEFAULT_REFRESH_ERROR_LOGGED_AS_WARNING = false;
 
     private final Duration backOffDelay;
     private final Duration minDelayBetweenRequests;
     private final Duration timeoutAutoAdjustmentMargin;
     private final boolean timeoutAutoAdjustmentEnabled;
+    private final boolean refreshErrorLoggedAsWarning;
 
     private CacheConfig(Duration backOffDelay, Duration minDelayBetweenRequests,
-                        boolean timeoutAutoAdjustmentEnabled, Duration timeoutAutoAdjustmentMargin) {
+                        boolean timeoutAutoAdjustmentEnabled, Duration timeoutAutoAdjustmentMargin,
+                        boolean refreshErrorLoggedAsWarning) {
         this.backOffDelay = backOffDelay;
         this.minDelayBetweenRequests = minDelayBetweenRequests;
         this.timeoutAutoAdjustmentEnabled = timeoutAutoAdjustmentEnabled;
         this.timeoutAutoAdjustmentMargin = timeoutAutoAdjustmentMargin;
+        this.refreshErrorLoggedAsWarning = refreshErrorLoggedAsWarning;
     }
 
     /**
@@ -71,6 +72,14 @@ public class CacheConfig {
     }
 
     /**
+     * Should refresh error be logged as warning?
+     * @return true if they should be logged as warning, false if they should remain error.
+     */
+    public boolean isRefreshErrorLoggedAsWarning() {
+        return refreshErrorLoggedAsWarning;
+    }
+
+    /**
      * Creates a new {@link CacheConfig.Builder} object.
      *
      * @return A new Consul builder.
@@ -84,6 +93,7 @@ public class CacheConfig {
         private Duration minDelayBetweenRequests = DEFAULT_MIN_DELAY_BETWEEN_REQUESTS;
         private Duration timeoutAutoAdjustmentMargin = DEFAULT_TIMEOUT_AUTO_ADJUSTMENT_MARGIN;
         private boolean timeoutAutoAdjustmentEnabled = DEFAULT_TIMEOUT_AUTO_ADJUSTMENT_ENABLED;
+        private boolean refreshErrorLoggedAsWarning = DEFAULT_REFRESH_ERROR_LOGGED_AS_WARNING;
 
         private Builder() {
 
@@ -122,9 +132,26 @@ public class CacheConfig {
             return this;
         }
 
+        /**
+         * Sets refresh error log level as warning
+         */
+        public Builder withRefreshErrorLoggedAsWarning() {
+            this.refreshErrorLoggedAsWarning = true;
+            return this;
+        }
+
+        /**
+         * Sets refresh error log level as error
+         */
+        public Builder withRefreshErrorLoggedAsError() {
+            this.refreshErrorLoggedAsWarning = false;
+            return this;
+        }
+
         public CacheConfig build() {
             return new CacheConfig(backOffDelay, minDelayBetweenRequests,
-                    timeoutAutoAdjustmentEnabled, timeoutAutoAdjustmentMargin);
+                    timeoutAutoAdjustmentEnabled, timeoutAutoAdjustmentMargin,
+                    refreshErrorLoggedAsWarning);
         }
     }
 }

--- a/src/test/java/com/orbitz/consul/config/CacheConfigTest.java
+++ b/src/test/java/com/orbitz/consul/config/CacheConfigTest.java
@@ -21,6 +21,7 @@ public class CacheConfigTest {
         assertEquals(CacheConfig.DEFAULT_MIN_DELAY_BETWEEN_REQUESTS, config.getMinimumDurationBetweenRequests());
         assertEquals(CacheConfig.DEFAULT_TIMEOUT_AUTO_ADJUSTMENT_ENABLED, config.isTimeoutAutoAdjustmentEnabled());
         assertEquals(CacheConfig.DEFAULT_TIMEOUT_AUTO_ADJUSTMENT_MARGIN, config.getTimeoutAutoAdjustmentMargin());
+        assertEquals(CacheConfig.DEFAULT_REFRESH_ERROR_LOGGED_AS_WARNING, config.isRefreshErrorLoggedAsWarning());
     }
 
     @Test
@@ -53,6 +54,16 @@ public class CacheConfigTest {
     public void testOverrideTimeoutAutoAdjustmentMargin(Duration margin) {
         CacheConfig config = CacheConfig.builder().withTimeoutAutoAdjustmentMargin(margin).build();
         assertEquals(margin, config.getTimeoutAutoAdjustmentMargin());
+    }
+
+    @Test
+    @Parameters({"true", "false"})
+    @TestCaseName("LogLevel as Warning: {0}")
+    public void testOverrideRefreshErrorLogLevel(boolean logLevelWarning) {
+        CacheConfig config = logLevelWarning
+                ? CacheConfig.builder().withRefreshErrorLoggedAsWarning().build()
+                : CacheConfig.builder().withRefreshErrorLoggedAsError().build();
+        assertEquals(logLevelWarning, config.isRefreshErrorLoggedAsWarning());
     }
 
     public Object getDurationSamples() {


### PR DESCRIPTION
It is "normal" that the application cannot sometimes reach the consul agent.
For instance, consul client or server restart after an upgrade triggers too many error logs.
Hence, logging as Warning would be a good option (default to false to keep current behavior).