### PR TITLE
Add support for Service meta data

### DIFF
--- a/src/main/java/com/orbitz/consul/AgentClient.java
+++ b/src/main/java/com/orbitz/consul/AgentClient.java
@@ -1,6 +1,7 @@
 package com.orbitz.consul;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
 import com.orbitz.consul.config.ClientConfig;
 import com.orbitz.consul.model.State;
@@ -69,6 +70,14 @@ public class AgentClient extends BaseClient {
     }
 
     /**
+     * @deprecated use {@link #register(int, long, String, String, List, Map)} instead
+     */
+    @Deprecated
+    public void register(int port, long ttl, String name, String id, String... tags) {
+        register(port, ttl, name, id, Lists.newArrayList(tags), Collections.emptyMap());
+    }
+
+    /**
      * Registers the client as a service with Consul with a ttl check.
      *
      * @param port The public facing port of the service to register with Consul.
@@ -76,10 +85,19 @@ public class AgentClient extends BaseClient {
      * @param name Service name to register.
      * @param id   Service id to register.
      * @param tags Tags to register with.
+     * @param meta Meta to register with.
      */
-    public void register(int port, long ttl, String name, String id, String... tags) {
+    public void register(int port, long ttl, String name, String id, List<String> tags, Map<String, String> meta) {
         Registration.RegCheck check = Registration.RegCheck.ttl(ttl);
-        register(port, check, name, id, tags);
+        register(port, check, name, id, tags, meta);
+    }
+
+    /**
+     * @deprecated use {@link #register(int, String, long, String, String, List, Map)} instead
+     */
+    @Deprecated
+    public void register(int port, String script, long interval, String name, String id, String... tags) {
+        register(port, script, interval, name, id, Lists.newArrayList(tags), Collections.emptyMap());
     }
 
     /**
@@ -91,10 +109,20 @@ public class AgentClient extends BaseClient {
      * @param name     Service name to register.
      * @param id       Service id to register.
      * @param tags     Tags to register with.
+     * @param meta     Meta to register with.
      */
-    public void register(int port, String script, long interval, String name, String id, String... tags) {
+    public void register(int port, String script, long interval, String name, String id,
+                         List<String> tags, Map<String, String> meta) {
         Registration.RegCheck check = Registration.RegCheck.script(script, interval);
-        register(port, check, name, id, tags);
+        register(port, check, name, id, tags, meta);
+    }
+
+    /**
+     * @deprecated use {@link #register(int, URL, long, String, String, List, Map)} instead
+     */
+    @Deprecated
+    public void register(int port, URL http, long interval, String name, String id, String... tags) {
+        register(port, http, interval, name, id, Lists.newArrayList(tags), Collections.emptyMap());
     }
 
     /**
@@ -106,10 +134,20 @@ public class AgentClient extends BaseClient {
      * @param name     Service name to register.
      * @param id       Service id to register.
      * @param tags     Tags to register with.
+     * @param meta     Meta to register with.
      */
-    public void register(int port, URL http, long interval, String name, String id, String... tags) {
+    public void register(int port, URL http, long interval, String name, String id,
+                         List<String> tags, Map<String, String> meta) {
         Registration.RegCheck check = Registration.RegCheck.http(http.toExternalForm(), interval);
-        register(port, check, name, id, tags);
+        register(port, check, name, id, tags, meta);
+    }
+
+    /**
+     * @deprecated use {@link #register(int, HostAndPort, long, String, String, List, Map)} instead
+     */
+    @Deprecated
+    public void register(int port, HostAndPort tcp, long interval, String name, String id, String... tags) {
+        register(port, tcp, interval, name, id, Lists.newArrayList(tags), Collections.emptyMap());
     }
 
     /**
@@ -121,10 +159,19 @@ public class AgentClient extends BaseClient {
      * @param name     Service name to register.
      * @param id       Service id to register.
      * @param tags     Tags to register with.
+     * @param meta     Meta to register with.
      */
-    public void register(int port, HostAndPort tcp, long interval, String name, String id, String... tags) {
+    public void register(int port, HostAndPort tcp, long interval, String name, String id,
+                         List<String> tags, Map<String, String> meta) {
         Registration.RegCheck check = Registration.RegCheck.tcp(tcp.toString(), interval);
-        register(port, check, name, id, tags);
+        register(port, check, name, id, tags, meta);
+    }
+
+    /**
+     * @deprecated use {@link #register(int, Registration.RegCheck, String, String, List, Map)} instead
+     */
+    public void register(int port, Registration.RegCheck check, String name, String id, String... tags) {
+        register(port, check, name, id, Lists.newArrayList(tags), Collections.emptyMap());
     }
 
     /**
@@ -135,18 +182,29 @@ public class AgentClient extends BaseClient {
      * @param name  Service name to register.
      * @param id    Service id to register.
      * @param tags  Tags to register with.
+     * @param meta  Meta to register with.
      */
-    public void register(int port, Registration.RegCheck check, String name, String id, String... tags) {
+    public void register(int port, Registration.RegCheck check, String name, String id,
+                         List<String> tags, Map<String, String> meta) {
         Registration registration = ImmutableRegistration
                 .builder()
                 .port(port)
                 .check(Optional.ofNullable(check))
                 .name(name)
                 .id(id)
-                .addTags(tags)
+                .tags(tags)
+                .meta(meta)
                 .build();
 
         register(registration);
+    }
+
+    /**
+     * @deprecated use {@link #register(int, List, String, String, List, Map)} instead
+     */
+    @Deprecated
+    public void register(int port, List<Registration.RegCheck> checks, String name, String id, String... tags) {
+        register(port, checks, name, id, Lists.newArrayList(tags), Collections.emptyMap());
     }
 
     /**
@@ -157,15 +215,18 @@ public class AgentClient extends BaseClient {
      * @param name  Service name to register.
      * @param id    Service id to register.
      * @param tags  Tags to register with.
+     * @param meta  Meta to register with.
      */
-    public void register(int port, List<Registration.RegCheck> checks, String name, String id, String... tags) {
+    public void register(int port, List<Registration.RegCheck> checks, String name, String id,
+                         List<String> tags, Map<String, String> meta) {
         Registration registration = ImmutableRegistration
                 .builder()
                 .port(port)
                 .checks(checks)
                 .name(name)
                 .id(id)
-                .addTags(tags)
+                .tags(tags)
+                .meta(meta)
                 .build();
 
         register(registration);

--- a/src/main/java/com/orbitz/consul/model/agent/Registration.java
+++ b/src/main/java/com/orbitz/consul/model/agent/Registration.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.util.Map;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -40,6 +42,9 @@ public abstract class Registration {
 
     @JsonProperty("Tags")
     public abstract List<String> getTags();
+
+    @JsonProperty("Meta")
+    public abstract Map<String,String> getMeta();
 
     @JsonProperty("EnableTagOverride")
     public abstract Optional<Boolean> getEnableTagOverride();

--- a/src/main/java/com/orbitz/consul/model/catalog/CatalogService.java
+++ b/src/main/java/com/orbitz/consul/model/catalog/CatalogService.java
@@ -40,6 +40,9 @@ public abstract class CatalogService {
     @JsonProperty("ServiceTags")
     public abstract List<String> getServiceTags();
 
+    @JsonProperty("ServiceMeta")
+    public abstract Optional<Map<String,String>> getServiceMeta();
+
     @JsonProperty("NodeMeta")
     public abstract Optional<Map<String,String>> getNodeMeta();
 }

--- a/src/main/java/com/orbitz/consul/model/health/Service.java
+++ b/src/main/java/com/orbitz/consul/model/health/Service.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableList;
 import org.immutables.value.Value;
 
 import java.util.List;
+import java.util.Map;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableService.class)
@@ -27,6 +28,9 @@ public abstract class Service {
     
     @JsonProperty("Address")
     public abstract  String getAddress();
+
+    @JsonProperty("Meta")
+    public abstract Map<String,String> getMeta();
 
     @JsonProperty("Port")
     public abstract  int getPort();

--- a/src/test/java/com/orbitz/consul/HealthTests.java
+++ b/src/test/java/com/orbitz/consul/HealthTests.java
@@ -14,7 +14,9 @@ import org.junit.Test;
 
 import java.math.BigInteger;
 import java.net.UnknownHostException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static com.orbitz.consul.Consul.builder;
@@ -23,19 +25,22 @@ import static org.junit.Assert.assertTrue;
 
 public class HealthTests extends BaseIntegrationTest {
 
+    private static final List<String> NO_TAGS = Collections.emptyList();
+    private static final Map<String, String> NO_META = Collections.emptyMap();
+
     @Test
     @Ignore
     public void shouldFetchPassingNode() throws UnknownHostException, NotRegisteredException {
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
-        client.agentClient().register(8080, 20L, serviceName, serviceId);
+        client.agentClient().register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         client.agentClient().pass(serviceId);
 
         Consul client2 = builder().withHostAndPort(HostAndPort.fromParts("localhost", 8500)).build();
         String serviceId2 = UUID.randomUUID().toString();
 
-        client2.agentClient().register(8080, 20L, serviceName, serviceId2);
+        client2.agentClient().register(8080, 20L, serviceName, serviceId2, NO_TAGS, NO_META);
         client2.agentClient().fail(serviceId2);
 
         ConsulResponse<List<ServiceHealth>> response = client2.healthClient().getHealthyServiceInstances(serviceName);
@@ -50,7 +55,7 @@ public class HealthTests extends BaseIntegrationTest {
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
-        client.agentClient().register(8080, 20L, serviceName, serviceId);
+        client.agentClient().register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         client.agentClient().pass(serviceId);
 
         ConsulResponse<List<ServiceHealth>> response = client.healthClient().getAllServiceInstances(serviceName);
@@ -64,7 +69,7 @@ public class HealthTests extends BaseIntegrationTest {
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
-        client.agentClient().register(8080, 20L, serviceName, serviceId);
+        client.agentClient().register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         client.agentClient().pass(serviceId);
 
         ConsulResponse<List<ServiceHealth>> response = client.healthClient().getAllServiceInstances(serviceName,
@@ -78,7 +83,7 @@ public class HealthTests extends BaseIntegrationTest {
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
-        client.agentClient().register(8080, 20L, serviceName, serviceId);
+        client.agentClient().register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         client.agentClient().pass(serviceId);
 
         ConsulResponse<List<ServiceHealth>> response = client.healthClient().getAllServiceInstances(serviceName,
@@ -124,7 +129,7 @@ public class HealthTests extends BaseIntegrationTest {
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
-        client.agentClient().register(8080, 20L, serviceName, serviceId);
+        client.agentClient().register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         client.agentClient().warn(serviceId);
 
         boolean found = false;

--- a/src/test/java/com/orbitz/consul/SnapshotClientTest.java
+++ b/src/test/java/com/orbitz/consul/SnapshotClientTest.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -45,7 +46,8 @@ public class SnapshotClientTest extends BaseIntegrationTest {
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
-        client.agentClient().register(8080, new URL("http://localhost:123/health"), 1000L, serviceName, serviceId);
+        client.agentClient().register(8080, new URL("http://localhost:123/health"), 1000L, serviceName, serviceId,
+                Collections.emptyList(), Collections.emptyMap());
         Synchroniser.pause(Duration.ofMillis(100));
         assertTrue(checkIfServiceExist(serviceName));
 

--- a/src/test/java/com/orbitz/consul/cache/ServiceCatalogCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/ServiceCatalogCacheTest.java
@@ -4,12 +4,10 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import com.orbitz.consul.BaseIntegrationTest;
 import com.orbitz.consul.model.catalog.CatalogService;
 import com.orbitz.consul.util.Synchroniser;
-import org.junit.Assert;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -20,7 +18,9 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.*;
 
 public class ServiceCatalogCacheTest extends BaseIntegrationTest {
-    private static final Logger log = LoggerFactory.getLogger(ServiceCatalogCacheTest.class);
+
+    private static final List<String> NO_TAGS = Collections.emptyList();
+    private static final Map<String, String> NO_META = Collections.emptyMap();
 
     @Test
     public void testWatchService() throws InterruptedException {
@@ -40,9 +40,9 @@ public class ServiceCatalogCacheTest extends BaseIntegrationTest {
         cache.start();
         cache.awaitInitialized(3, TimeUnit.SECONDS);
 
-        client.agentClient().register(20001, 20, name, serviceId1);
+        client.agentClient().register(20001, 20, name, serviceId1, NO_TAGS, NO_META);
         Synchroniser.pause(Duration.ofMillis(100));
-        client.agentClient().register(20002, 20, name, serviceId2);
+        client.agentClient().register(20002, 20, name, serviceId2, NO_TAGS, NO_META);
 
         Uninterruptibles.awaitUninterruptibly(finish, 1, TimeUnit.SECONDS);
 

--- a/src/test/java/com/orbitz/consul/cache/ServiceHealthCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/ServiceHealthCacheTest.java
@@ -16,13 +16,16 @@ import static org.junit.Assert.*;
 
 public class ServiceHealthCacheTest extends BaseIntegrationTest {
 
+    private static final List<String> NO_TAGS = Collections.emptyList();
+    private static final Map<String, String> NO_META = Collections.emptyMap();
+
     @Test
     public void nodeCacheServicePassingTest() throws Exception {
         HealthClient healthClient = client.healthClient();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
-        client.agentClient().register(8080, 20L, serviceName, serviceId);
+        client.agentClient().register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         client.agentClient().pass(serviceId);
         Synchroniser.pause(Duration.ofMillis(100));
 
@@ -51,10 +54,10 @@ public class ServiceHealthCacheTest extends BaseIntegrationTest {
         String serviceId = UUID.randomUUID().toString();
         String serviceId2 = UUID.randomUUID().toString();
 
-        client.agentClient().register(8080, 20L, serviceName, serviceId);
+        client.agentClient().register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         client.agentClient().pass(serviceId);
 
-        client.agentClient().register(8080, 20L, serviceName, serviceId2);
+        client.agentClient().register(8080, 20L, serviceName, serviceId2, NO_TAGS, NO_META);
         client.agentClient().pass(serviceId2);
 
         try (ServiceHealthCache svHealth = ServiceHealthCache.newCache(healthClient, serviceName)) {
@@ -89,7 +92,7 @@ public class ServiceHealthCacheTest extends BaseIntegrationTest {
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
-        client.agentClient().register(8080, 20L, serviceName, serviceId);
+        client.agentClient().register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         client.agentClient().pass(serviceId);
 
         ServiceHealthCache svHealth = ServiceHealthCache.newCache(client.healthClient(), serviceName);


### PR DESCRIPTION
Adding support for meta data (see https://github.com/rickfast/consul-client/issues/321).
We should be able to:
 - register a service with meta data in an agent
 - register a service with meta data in the catalog
 - retrieve the meta data of a service (catalog, health, cache)