### PR TITLE
Support EnableTagOverride during service registration

### DIFF
--- a/src/main/java/com/orbitz/consul/model/catalog/CatalogRegistration.java
+++ b/src/main/java/com/orbitz/consul/model/catalog/CatalogRegistration.java
@@ -35,4 +35,5 @@ public abstract class CatalogRegistration {
 
     @JsonProperty("WriteRequest")
     public abstract Optional<WriteRequest> writeRequest();
+
 }

--- a/src/main/java/com/orbitz/consul/model/catalog/CatalogRegistration.java
+++ b/src/main/java/com/orbitz/consul/model/catalog/CatalogRegistration.java
@@ -35,5 +35,4 @@ public abstract class CatalogRegistration {
 
     @JsonProperty("WriteRequest")
     public abstract Optional<WriteRequest> writeRequest();
-
 }

--- a/src/main/java/com/orbitz/consul/model/catalog/CatalogService.java
+++ b/src/main/java/com/orbitz/consul/model/catalog/CatalogService.java
@@ -34,6 +34,9 @@ public abstract class CatalogService {
     @JsonProperty("ServiceAddress")
     public abstract String getServiceAddress();
 
+    @JsonProperty("ServiceEnableTagOverride")
+    public abstract Optional<Boolean> getServiceEnableTagOverride();
+
     @JsonProperty("ServicePort")
     public abstract int getServicePort();
 

--- a/src/main/java/com/orbitz/consul/model/health/Service.java
+++ b/src/main/java/com/orbitz/consul/model/health/Service.java
@@ -9,6 +9,7 @@ import org.immutables.value.Value;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableService.class)
@@ -17,21 +18,24 @@ import java.util.Map;
 public abstract class Service {
 
     @JsonProperty("ID")
-    public abstract  String getId();
+    public abstract String getId();
 
     @JsonProperty("Service")
-    public abstract  String getService();
+    public abstract String getService();
+
+    @JsonProperty("EnableTagOverride")
+    public abstract Optional<Boolean> getEnableTagOverride();
 
     @JsonProperty("Tags")
     @JsonDeserialize(as = ImmutableList.class, contentAs = String.class)
     public abstract List<String> getTags();
     
     @JsonProperty("Address")
-    public abstract  String getAddress();
+    public abstract String getAddress();
 
     @JsonProperty("Meta")
     public abstract Map<String,String> getMeta();
 
     @JsonProperty("Port")
-    public abstract  int getPort();
+    public abstract int getPort();
 }

--- a/src/test/java/com/orbitz/consul/CatalogTests.java
+++ b/src/test/java/com/orbitz/consul/CatalogTests.java
@@ -133,6 +133,7 @@ public class CatalogTests extends BaseIntegrationTest {
                 .serviceName(service)
                 .servicePort(8080)
                 .serviceMeta(Collections.singletonMap("metakey", "metavalue"))
+                .serviceEnableTagOverride(true)
                 .build();
 
         CatalogRegistration registration = ImmutableCatalogRegistration.builder()
@@ -146,6 +147,7 @@ public class CatalogTests extends BaseIntegrationTest {
                         .service(service)
                         .port(8080)
                         .putMeta("metakey", "metavalue")
+                        .enableTagOverride(true) //setting this request flag sets the ServiceEnableTagOverride in the response
                         .build())
                 .build();
         catalogClient.register(registration);


### PR DESCRIPTION
Supports setting the `EnableTagOverride` option during service registration with the catalog. The flag was already supported using the Agent API, but not the Catalog API. 

Documentation on this feature is a bit thin - it's alluded to in the _response_ of the [official API docs](https://www.consul.io/api/catalog.html) but not in the _request_. It is discussed in some depth in [Issue 1572 in the main Consul repo](https://github.com/hashicorp/consul/issues/1572#issuecomment-170155251) (in particular the code under "Update the tag using the catalog" in that comment). It is actually supported, as shown in the modified test. 

Pulling out my non-existent skills at reading Go to dive into the source, I'm fairly sure that [we can see here](https://github.com/hashicorp/consul/blob/master/api/catalog.go#L44) that the request uses an `AgentService` struct, which [has the `EnableTagOverride` field](https://github.com/hashicorp/consul/blob/master/api/agent.go#L29). And then the [response has the `ServiceEnableTagOverride` field](https://github.com/hashicorp/consul/blob/master/api/catalog.go#L27). Though again, I could well be reading that wrong. 

Apologies if I'm skipping part of the process. If you would like an issue opened or something else done then I'm happy to do so. 