### PR TITLE
Enable custom log function in case of cache refresh error

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -144,11 +144,7 @@ public class ConsulCache<K, V> implements AutoCloseable {
                 String message = String.format("Error getting response from consul. will retry in %d %s",
                         cacheConfig.getBackOffDelay().toMillis(), TimeUnit.MILLISECONDS);
 
-                if (cacheConfig.isRefreshErrorLoggedAsWarning()) {
-                    LOGGER.warn(message, throwable);
-                } else {
-                    LOGGER.error(message, throwable);
-                }
+                cacheConfig.getRefreshErrorLoggingConsumer().accept(LOGGER, message, throwable);
 
                 executorService.schedule(ConsulCache.this::runCallback,
                         cacheConfig.getBackOffDelay().toMillis(), TimeUnit.MILLISECONDS);

--- a/src/test/java/com/orbitz/consul/config/CacheConfigTest.java
+++ b/src/test/java/com/orbitz/consul/config/CacheConfigTest.java
@@ -5,10 +5,17 @@ import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
 @RunWith(JUnitParamsRunner.class)
 public class CacheConfigTest {
@@ -21,7 +28,15 @@ public class CacheConfigTest {
         assertEquals(CacheConfig.DEFAULT_MIN_DELAY_BETWEEN_REQUESTS, config.getMinimumDurationBetweenRequests());
         assertEquals(CacheConfig.DEFAULT_TIMEOUT_AUTO_ADJUSTMENT_ENABLED, config.isTimeoutAutoAdjustmentEnabled());
         assertEquals(CacheConfig.DEFAULT_TIMEOUT_AUTO_ADJUSTMENT_MARGIN, config.getTimeoutAutoAdjustmentMargin());
-        assertEquals(CacheConfig.DEFAULT_REFRESH_ERROR_LOGGED_AS_WARNING, config.isRefreshErrorLoggedAsWarning());
+
+        AtomicBoolean loggedAsWarn = new AtomicBoolean(false);
+        Logger logger = mock(Logger.class);
+        doAnswer(vars -> {
+            loggedAsWarn.set(true);
+            return null;
+        }).when(logger).error(anyString(), any(Throwable.class));
+        config.getRefreshErrorLoggingConsumer().accept(logger, null, null);
+        assertTrue("Should have logged as warning", loggedAsWarn.get());
     }
 
     @Test
@@ -59,11 +74,42 @@ public class CacheConfigTest {
     @Test
     @Parameters({"true", "false"})
     @TestCaseName("LogLevel as Warning: {0}")
-    public void testOverrideRefreshErrorLogLevel(boolean logLevelWarning) {
+    public void testOverrideRefreshErrorLogConsumer(boolean logLevelWarning) throws InterruptedException {
         CacheConfig config = logLevelWarning
                 ? CacheConfig.builder().withRefreshErrorLoggedAsWarning().build()
                 : CacheConfig.builder().withRefreshErrorLoggedAsError().build();
-        assertEquals(logLevelWarning, config.isRefreshErrorLoggedAsWarning());
+
+        AtomicBoolean logged = new AtomicBoolean(false);
+        AtomicBoolean loggedAsWarn = new AtomicBoolean(false);
+        Logger logger = mock(Logger.class);
+        doAnswer(vars -> {
+            loggedAsWarn.set(true);
+            logged.set(true);
+            return null;
+        }).when(logger).warn(anyString(), any(Throwable.class));
+        doAnswer(vars -> {
+            loggedAsWarn.set(false);
+            logged.set(true);
+            return null;
+        }).when(logger).error(anyString(), any(Throwable.class));
+
+        config.getRefreshErrorLoggingConsumer().accept(logger, null, null);
+        assertTrue(logged.get());
+        assertEquals(logLevelWarning, loggedAsWarn.get());
+    }
+
+    @Test
+    public void testOverrideRefreshErrorLogCustom() {
+        AtomicBoolean loggedAsDebug = new AtomicBoolean(false);
+        Logger logger = mock(Logger.class);
+        doAnswer(vars -> {
+            loggedAsDebug.set(true);
+            return null;
+        }).when(logger).debug(anyString(), any(Throwable.class));
+
+        CacheConfig config = CacheConfig.builder().withRefreshErrorLoggedAs(Logger::debug).build();
+        config.getRefreshErrorLoggingConsumer().accept(logger, null, null);
+        assertTrue(loggedAsDebug.get());
     }
 
     public Object getDurationSamples() {


### PR DESCRIPTION
We need to log sometimes as error, sometimes as warning.
Also, we would like to not log the same error every time (wait a few minutes in between).
This is specific to our use case.

Hence, we here allow setting a custom consumer to log on cache refresh error.
The behavior of caches for those who don't need this feature will remain unchanged.