### PR TITLE
Display logs in test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <retrofit.version>2.3.0</retrofit.version>
         <okhttp.version>3.9.0</okhttp.version>
         <slf4j.version>1.7.21</slf4j.version>
+        <logback.version>1.2.3</logback.version>
     </properties>
     <distributionManagement>
         <snapshotRepository>
@@ -144,6 +145,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="DEBUG">
+        <appender-ref ref="CONSOLE" />
+    </root>
+</configuration>


### PR DESCRIPTION
When playing tests, we might want to see the logs.
However, logs are not available as no implementation of slf4j is present.
Add slf4j implementaion for test only.

Example of output:
`10:23:15.307 [OkHttp http://localhost:8500/...] DEBUG com.orbitz.consul.cache.ConsulCache - Consul cache updated (index=672), request duration: 274 ms`