### PR TITLE
Add more details in cache logs

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -67,7 +67,8 @@ public class ConsulCache<K, V> implements AutoCloseable {
             Function<V, K> keyConversion,
             CallbackConsumer<V> callbackConsumer,
             CacheConfig cacheConfig,
-            ClientEventHandler eventHandler) {
+            ClientEventHandler eventHandler,
+            String cacheDescriptor) {
 
         this.keyConversion = keyConversion;
         this.callBackConsumer = callbackConsumer;
@@ -83,8 +84,8 @@ public class ConsulCache<K, V> implements AutoCloseable {
                     }
                     Duration elapsedTime = stopWatch.elapsed();
                     updateIndex(consulResponse);
-                    LOGGER.debug("Consul cache updated (index={}), request duration: {} ms",
-                            latestIndex, elapsedTime.toMillis());
+                    LOGGER.debug("Consul cache updated for {} (index={}), request duration: {} ms",
+                            cacheDescriptor, latestIndex, elapsedTime.toMillis());
 
                     ImmutableMap<K, V> full = convertToMap(consulResponse);
 
@@ -141,8 +142,8 @@ public class ConsulCache<K, V> implements AutoCloseable {
                 }
                 eventHandler.cachePollingError(throwable);
 
-                String message = String.format("Error getting response from consul. will retry in %d %s",
-                        cacheConfig.getBackOffDelay().toMillis(), TimeUnit.MILLISECONDS);
+                String message = String.format("Error getting response from consul for %s, will retry in %d %s",
+                        cacheDescriptor, cacheConfig.getBackOffDelay().toMillis(), TimeUnit.MILLISECONDS);
 
                 cacheConfig.getRefreshErrorLoggingConsumer().accept(LOGGER, message, throwable);
 

--- a/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
+++ b/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
@@ -14,8 +14,9 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
     private HealthCheckCache(Function<HealthCheck, String> keyConversion,
                              CallbackConsumer<HealthCheck> callbackConsumer,
                              CacheConfig cacheConfig,
-                             ClientEventHandler eventHandler) {
-        super(keyConversion, callbackConsumer, cacheConfig, eventHandler);
+                             ClientEventHandler eventHandler,
+                             String cacheDescriptor) {
+        super(keyConversion, callbackConsumer, cacheConfig, eventHandler, cacheDescriptor);
     }
 
     /**
@@ -41,7 +42,8 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
         return new HealthCheckCache(keyExtractor,
                 callbackConsumer,
                 healthClient.getConfig().getCacheConfig(),
-                healthClient.getEventHandler());
+                healthClient.getEventHandler(),
+                String.format("state \"%s\"", state.getName()));
     }
 
     public static HealthCheckCache newCache(

--- a/src/main/java/com/orbitz/consul/cache/KVCache.java
+++ b/src/main/java/com/orbitz/consul/cache/KVCache.java
@@ -16,8 +16,9 @@ public class KVCache extends ConsulCache<String, Value> {
     private KVCache(Function<Value, String> keyConversion,
                     ConsulCache.CallbackConsumer<Value> callbackConsumer,
                     CacheConfig cacheConfig,
-                    ClientEventHandler eventHandler) {
-        super(keyConversion, callbackConsumer, cacheConfig, eventHandler);
+                    ClientEventHandler eventHandler,
+                    String cacheDescriptor) {
+        super(keyConversion, callbackConsumer, cacheConfig, eventHandler, cacheDescriptor);
     }
 
     @VisibleForTesting
@@ -55,7 +56,8 @@ public class KVCache extends ConsulCache<String, Value> {
         return new KVCache(keyExtractor,
                 callbackConsumer,
                 kvClient.getConfig().getCacheConfig(),
-                kvClient.getEventHandler());
+                kvClient.getEventHandler(),
+                String.format("key \"%s\"", rootPath));
     }
 
     @VisibleForTesting

--- a/src/main/java/com/orbitz/consul/cache/NodesCatalogCache.java
+++ b/src/main/java/com/orbitz/consul/cache/NodesCatalogCache.java
@@ -15,7 +15,7 @@ public class NodesCatalogCache extends ConsulCache<String, Node> {
                               CallbackConsumer<Node> callbackConsumer,
                               CacheConfig cacheConfig,
                               ClientEventHandler eventHandler) {
-        super(keyConversion, callbackConsumer, cacheConfig, eventHandler);
+        super(keyConversion, callbackConsumer, cacheConfig, eventHandler, "nodes");
     }
 
     public static NodesCatalogCache newCache(

--- a/src/main/java/com/orbitz/consul/cache/ServiceCatalogCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ServiceCatalogCache.java
@@ -17,8 +17,9 @@ public class ServiceCatalogCache extends ConsulCache<String, CatalogService> {
     private ServiceCatalogCache(Function<CatalogService, String> keyConversion,
                                 CallbackConsumer<CatalogService> callbackConsumer,
                                 CacheConfig cacheConfig,
-                                ClientEventHandler eventHandler) {
-        super(keyConversion, callbackConsumer, cacheConfig, eventHandler);
+                                ClientEventHandler eventHandler,
+                                String cacheDescriptor) {
+        super(keyConversion, callbackConsumer, cacheConfig, eventHandler, cacheDescriptor);
     }
 
     public static ServiceCatalogCache newCache(
@@ -33,7 +34,8 @@ public class ServiceCatalogCache extends ConsulCache<String, CatalogService> {
         return new ServiceCatalogCache(CatalogService::getServiceId,
                 callbackConsumer,
                 catalogClient.getConfig().getCacheConfig(),
-                catalogClient.getEventHandler());
+                catalogClient.getEventHandler(),
+                String.format("catalog service \"%s\"", serviceName));
     }
 
     public static ServiceCatalogCache newCache(final CatalogClient catalogClient, final String serviceName) {

--- a/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
@@ -15,8 +15,9 @@ public class ServiceHealthCache extends ConsulCache<ServiceHealthKey, ServiceHea
     private ServiceHealthCache(Function<ServiceHealth, ServiceHealthKey> keyConversion,
                                CallbackConsumer<ServiceHealth> callbackConsumer,
                                CacheConfig cacheConfig,
-                               ClientEventHandler eventHandler) {
-        super(keyConversion, callbackConsumer, cacheConfig, eventHandler);
+                               ClientEventHandler eventHandler,
+                               String cacheDescriptor) {
+        super(keyConversion, callbackConsumer, cacheConfig, eventHandler, cacheDescriptor);
     }
 
     /**
@@ -49,7 +50,8 @@ public class ServiceHealthCache extends ConsulCache<ServiceHealthKey, ServiceHea
         return new ServiceHealthCache(keyExtractor,
                 callbackConsumer,
                 healthClient.getConfig().getCacheConfig(),
-                healthClient.getEventHandler());
+                healthClient.getEventHandler(),
+                String.format("health service \"%s\"", serviceName));
     }
 
     public static ServiceHealthCache newCache(

--- a/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
@@ -32,7 +32,7 @@ public class ConsulCacheTest extends BaseIntegrationTest {
         final List<Value> response = Arrays.asList(mock(Value.class), mock(Value.class));
         CacheConfig cacheConfig = mock(CacheConfig.class);
         ClientEventHandler eventHandler = mock(ClientEventHandler.class);
-        final ConsulCache<String, Value> consulCache = new ConsulCache<>(keyExtractor, null, cacheConfig, eventHandler);
+        final ConsulCache<String, Value> consulCache = new ConsulCache<>(keyExtractor, null, cacheConfig, eventHandler, "");
         final ConsulResponse<List<Value>> consulResponse = new ConsulResponse<>(response, 0, false, BigInteger.ONE);
         final ImmutableMap<String, Value> map = consulCache.convertToMap(consulResponse);
         assertNotNull(map);


### PR DESCRIPTION
When several caches are used by the same app, it is hard to know which cache generated a log.
Add cache descriptor in the cache logs.