### PR TITLE
Improve cache event callback

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/CacheDescriptor.java
+++ b/src/main/java/com/orbitz/consul/cache/CacheDescriptor.java
@@ -1,5 +1,10 @@
 package com.orbitz.consul.cache;
 
+/**
+ * A {@link CacheDescriptor} describes an instance of a cache.
+ * The cache is represented by an {@link CacheDescriptor#endpoint} and a {@link CacheDescriptor#key}.
+ * For instance, a cache targeting "/v1/catalog/service/myService" will be represented by endpoint "catalog.service" and key "myService".
+ */
 public class CacheDescriptor {
 
     private final String endpoint;

--- a/src/main/java/com/orbitz/consul/cache/CacheDescriptor.java
+++ b/src/main/java/com/orbitz/consul/cache/CacheDescriptor.java
@@ -1,0 +1,32 @@
+package com.orbitz.consul.cache;
+
+public class CacheDescriptor {
+
+    private final String endpoint;
+    private final String key;
+
+    public CacheDescriptor(String endpoint) {
+        this(endpoint, null);
+    }
+
+    public CacheDescriptor(String endpoint, String key) {
+        this.endpoint = endpoint;
+        this.key = key;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    public String toString() {
+        if (key == null) {
+            return endpoint;
+        }
+        return String.format("%s \"%s\"", endpoint, key);
+    }
+}

--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -68,7 +68,7 @@ public class ConsulCache<K, V> implements AutoCloseable {
             CallbackConsumer<V> callbackConsumer,
             CacheConfig cacheConfig,
             ClientEventHandler eventHandler,
-            String cacheDescriptor) {
+            CacheDescriptor cacheDescriptor) {
 
         this.keyConversion = keyConversion;
         this.callBackConsumer = callbackConsumer;

--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -62,6 +62,7 @@ public class ConsulCache<K, V> implements AutoCloseable {
     private final CallbackConsumer<V> callBackConsumer;
     private final ConsulResponseCallback<List<V>> responseCallback;
     private final ClientEventHandler eventHandler;
+    private final CacheDescriptor cacheDescriptor;
 
     ConsulCache(
             Function<V, K> keyConversion,
@@ -73,6 +74,7 @@ public class ConsulCache<K, V> implements AutoCloseable {
         this.keyConversion = keyConversion;
         this.callBackConsumer = callbackConsumer;
         this.eventHandler = eventHandler;
+        this.cacheDescriptor = cacheDescriptor;
 
         this.responseCallback = new ConsulResponseCallback<List<V>>() {
             @Override
@@ -90,7 +92,7 @@ public class ConsulCache<K, V> implements AutoCloseable {
                     ImmutableMap<K, V> full = convertToMap(consulResponse);
 
                     boolean changed = !full.equals(lastResponse.get());
-                    eventHandler.cachePollingSuccess(changed, elapsedTime);
+                    eventHandler.cachePollingSuccess(cacheDescriptor, changed, elapsedTime);
 
                     if (changed) {
                         // changes
@@ -140,7 +142,7 @@ public class ConsulCache<K, V> implements AutoCloseable {
                 if (!isRunning()) {
                     return;
                 }
-                eventHandler.cachePollingError(throwable);
+                eventHandler.cachePollingError(cacheDescriptor, throwable);
                 long delayMs = computeBackOffDelayMs(cacheConfig);
                 String message = String.format("Error getting response from consul for %s, will retry in %d %s",
                         cacheDescriptor, delayMs, TimeUnit.MILLISECONDS);
@@ -159,12 +161,12 @@ public class ConsulCache<K, V> implements AutoCloseable {
 
     public void start() {
         checkState(state.compareAndSet(State.latent, State.starting),"Cannot transition from state %s to %s", state.get(), State.starting);
-        eventHandler.cacheStart();
+        eventHandler.cacheStart(cacheDescriptor);
         runCallback();
     }
 
     public void stop() {
-        eventHandler.cacheStop();
+        eventHandler.cacheStop(cacheDescriptor);
         State previous = state.getAndSet(State.stopped);
         if (stopWatch.isRunning()) {
             stopWatch.stop();

--- a/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
+++ b/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
@@ -15,7 +15,7 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
                              CallbackConsumer<HealthCheck> callbackConsumer,
                              CacheConfig cacheConfig,
                              ClientEventHandler eventHandler,
-                             String cacheDescriptor) {
+                             CacheDescriptor cacheDescriptor) {
         super(keyConversion, callbackConsumer, cacheConfig, eventHandler, cacheDescriptor);
     }
 
@@ -39,11 +39,13 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
             QueryOptions params = watchParams(index, watchSeconds, queryOptions);
             healthClient.getChecksByState(state, params, callback);
         };
+
+        CacheDescriptor cacheDescriptor = new CacheDescriptor("health.state", state.getName());
         return new HealthCheckCache(keyExtractor,
                 callbackConsumer,
                 healthClient.getConfig().getCacheConfig(),
                 healthClient.getEventHandler(),
-                String.format("state \"%s\"", state.getName()));
+                cacheDescriptor);
     }
 
     public static HealthCheckCache newCache(

--- a/src/main/java/com/orbitz/consul/cache/KVCache.java
+++ b/src/main/java/com/orbitz/consul/cache/KVCache.java
@@ -17,7 +17,7 @@ public class KVCache extends ConsulCache<String, Value> {
                     ConsulCache.CallbackConsumer<Value> callbackConsumer,
                     CacheConfig cacheConfig,
                     ClientEventHandler eventHandler,
-                    String cacheDescriptor) {
+                    CacheDescriptor cacheDescriptor) {
         super(keyConversion, callbackConsumer, cacheConfig, eventHandler, cacheDescriptor);
     }
 
@@ -53,11 +53,12 @@ public class KVCache extends ConsulCache<String, Value> {
             kvClient.getValues(keyPath, params, callback);
         };
 
+        CacheDescriptor cacheDescriptor = new CacheDescriptor("keyvalue", rootPath);
         return new KVCache(keyExtractor,
                 callbackConsumer,
                 kvClient.getConfig().getCacheConfig(),
                 kvClient.getEventHandler(),
-                String.format("key \"%s\"", rootPath));
+                cacheDescriptor);
     }
 
     @VisibleForTesting

--- a/src/main/java/com/orbitz/consul/cache/NodesCatalogCache.java
+++ b/src/main/java/com/orbitz/consul/cache/NodesCatalogCache.java
@@ -15,7 +15,7 @@ public class NodesCatalogCache extends ConsulCache<String, Node> {
                               CallbackConsumer<Node> callbackConsumer,
                               CacheConfig cacheConfig,
                               ClientEventHandler eventHandler) {
-        super(keyConversion, callbackConsumer, cacheConfig, eventHandler, "nodes");
+        super(keyConversion, callbackConsumer, cacheConfig, eventHandler, new CacheDescriptor("catalog.nodes"));
     }
 
     public static NodesCatalogCache newCache(

--- a/src/main/java/com/orbitz/consul/cache/ServiceCatalogCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ServiceCatalogCache.java
@@ -18,7 +18,7 @@ public class ServiceCatalogCache extends ConsulCache<String, CatalogService> {
                                 CallbackConsumer<CatalogService> callbackConsumer,
                                 CacheConfig cacheConfig,
                                 ClientEventHandler eventHandler,
-                                String cacheDescriptor) {
+                                CacheDescriptor cacheDescriptor) {
         super(keyConversion, callbackConsumer, cacheConfig, eventHandler, cacheDescriptor);
     }
 
@@ -31,11 +31,12 @@ public class ServiceCatalogCache extends ConsulCache<String, CatalogService> {
         final CallbackConsumer<CatalogService> callbackConsumer = (index, callback) ->
                 catalogClient.getService(serviceName, watchParams(index, watchSeconds, queryOptions), callback);
 
+        CacheDescriptor cacheDescriptor = new CacheDescriptor("catalog.service", serviceName);
         return new ServiceCatalogCache(CatalogService::getServiceId,
                 callbackConsumer,
                 catalogClient.getConfig().getCacheConfig(),
                 catalogClient.getEventHandler(),
-                String.format("catalog service \"%s\"", serviceName));
+                cacheDescriptor);
     }
 
     public static ServiceCatalogCache newCache(final CatalogClient catalogClient, final String serviceName) {

--- a/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
@@ -16,7 +16,7 @@ public class ServiceHealthCache extends ConsulCache<ServiceHealthKey, ServiceHea
                                CallbackConsumer<ServiceHealth> callbackConsumer,
                                CacheConfig cacheConfig,
                                ClientEventHandler eventHandler,
-                               String cacheDescriptor) {
+                               CacheDescriptor cacheDescriptor) {
         super(keyConversion, callbackConsumer, cacheConfig, eventHandler, cacheDescriptor);
     }
 
@@ -47,11 +47,12 @@ public class ServiceHealthCache extends ConsulCache<ServiceHealthKey, ServiceHea
             }
         };
 
+        CacheDescriptor cacheDescriptor = new CacheDescriptor("health.service", serviceName);
         return new ServiceHealthCache(keyExtractor,
                 callbackConsumer,
                 healthClient.getConfig().getCacheConfig(),
                 healthClient.getEventHandler(),
-                String.format("health service \"%s\"", serviceName));
+                cacheDescriptor);
     }
 
     public static ServiceHealthCache newCache(

--- a/src/main/java/com/orbitz/consul/monitoring/ClientEventCallback.java
+++ b/src/main/java/com/orbitz/consul/monitoring/ClientEventCallback.java
@@ -1,5 +1,7 @@
 package com.orbitz.consul.monitoring;
 
+import com.orbitz.consul.cache.CacheDescriptor;
+
 import java.time.Duration;
 
 public interface ClientEventCallback {
@@ -10,11 +12,11 @@ public interface ClientEventCallback {
 
     default void onHttpRequestInvalid(String clientName, String method, String queryString, Throwable throwable) { }
 
-    default void onCacheStart(String clientName) { }
+    default void onCacheStart(String clientName, CacheDescriptor cacheDescriptor) { }
 
-    default void onCacheStop(String clientName) { }
+    default void onCacheStop(String clientName, CacheDescriptor cacheDescriptor) { }
 
-    default void onCachePollingError(String clientName, Throwable throwable) { }
+    default void onCachePollingError(String clientName, CacheDescriptor cacheDescriptor, Throwable throwable) { }
 
-    default void onCachePollingSuccess(String clientName, boolean withNotification, Duration duration) { }
+    default void onCachePollingSuccess(String clientName, CacheDescriptor cacheDescriptor, boolean withNotification, Duration duration) { }
 }

--- a/src/main/java/com/orbitz/consul/monitoring/ClientEventHandler.java
+++ b/src/main/java/com/orbitz/consul/monitoring/ClientEventHandler.java
@@ -1,6 +1,7 @@
 package com.orbitz.consul.monitoring;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.orbitz.consul.cache.CacheDescriptor;
 import okhttp3.Request;
 
 import java.time.Duration;
@@ -34,20 +35,20 @@ public class ClientEventHandler {
                 callback.onHttpRequestFailure(clientName, request.method(), request.url().query(), throwable));
     }
 
-    public void cacheStart() {
-        EVENT_EXECUTOR.submit(() -> callback.onCacheStart(clientName));
+    public void cacheStart(CacheDescriptor cacheDescriptor) {
+        EVENT_EXECUTOR.submit(() -> callback.onCacheStart(clientName, cacheDescriptor));
     }
 
-    public void cacheStop() {
-        EVENT_EXECUTOR.submit(() -> callback.onCacheStop(clientName));
+    public void cacheStop(CacheDescriptor cacheDescriptor) {
+        EVENT_EXECUTOR.submit(() -> callback.onCacheStop(clientName, cacheDescriptor));
     }
 
-    public void cachePollingError(Throwable throwable) {
-        EVENT_EXECUTOR.submit(() -> callback.onCachePollingError(clientName, throwable));
+    public void cachePollingError(CacheDescriptor cacheDescriptor, Throwable throwable) {
+        EVENT_EXECUTOR.submit(() -> callback.onCachePollingError(clientName, cacheDescriptor, throwable));
     }
 
-    public void cachePollingSuccess(boolean withNotification, Duration duration) {
-        EVENT_EXECUTOR.submit(() -> callback.onCachePollingSuccess(clientName, withNotification, duration));
+    public void cachePollingSuccess(CacheDescriptor cacheDescriptor, boolean withNotification, Duration duration) {
+        EVENT_EXECUTOR.submit(() -> callback.onCachePollingSuccess(clientName, cacheDescriptor, withNotification, duration));
     }
 
 }

--- a/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
@@ -43,7 +43,7 @@ public class ConsulCacheTest extends BaseIntegrationTest {
         final List<Value> response = Arrays.asList(mock(Value.class), mock(Value.class));
         CacheConfig cacheConfig = mock(CacheConfig.class);
         ClientEventHandler eventHandler = mock(ClientEventHandler.class);
-        final ConsulCache<String, Value> consulCache = new ConsulCache<>(keyExtractor, null, cacheConfig, eventHandler, "");
+        final ConsulCache<String, Value> consulCache = new ConsulCache<>(keyExtractor, null, cacheConfig, eventHandler, new CacheDescriptor(""));
         final ConsulResponse<List<Value>> consulResponse = new ConsulResponse<>(response, 0, false, BigInteger.ONE);
         final ImmutableMap<String, Value> map = consulCache.convertToMap(consulResponse);
         assertNotNull(map);


### PR DESCRIPTION
Inject a better cache descriptor in cache, and propagate it into event callback.
This enables to have more fine grain event callback like:
 - number of cache start by endpoint
 - duration of requests per keys
 - etc, ...