### PR TITLE
Enable setting args when registering service check

### DIFF
--- a/src/itest/java/com/orbitz/consul/AgentITest.java
+++ b/src/itest/java/com/orbitz/consul/AgentITest.java
@@ -245,7 +245,7 @@ public class AgentITest extends BaseIntegrationTest {
         String serviceId = UUID.randomUUID().toString();
         String note = UUID.randomUUID().toString();
 
-        client.agentClient().register(8080, 20L, serviceName, serviceId);
+        client.agentClient().register(8080, 20L, serviceName, serviceId, Collections.emptyList(), Collections.emptyMap());
         client.agentClient().warn(serviceId, note);
 
         verifyState("warning", client, serviceId, serviceName, note);
@@ -257,7 +257,7 @@ public class AgentITest extends BaseIntegrationTest {
         String serviceId = UUID.randomUUID().toString();
         String note = UUID.randomUUID().toString();
 
-        client.agentClient().register(8080, 20L, serviceName, serviceId);
+        client.agentClient().register(8080, 20L, serviceName, serviceId, Collections.emptyList(), Collections.emptyMap());
         client.agentClient().fail(serviceId, note);
 
         verifyState("critical", client, serviceId, serviceName, note);

--- a/src/itest/java/com/orbitz/consul/AgentITest.java
+++ b/src/itest/java/com/orbitz/consul/AgentITest.java
@@ -126,7 +126,7 @@ public class AgentITest extends BaseIntegrationTest {
         String serviceId = UUID.randomUUID().toString();
 
         List<Registration.RegCheck> regChecks = ImmutableList.of(
-                Registration.RegCheck.script("/usr/bin/echo \"sup\"", 10, 1, "Custom description."),
+                Registration.RegCheck.args(Collections.singletonList("/usr/bin/echo \"sup\""), 10, 1, "Custom description."),
                 Registration.RegCheck.http("http://localhost:8080/health", 10, 1, "Custom description."));
 
         client.agentClient().register(8080, regChecks, serviceName, serviceId, NO_TAGS, NO_META);
@@ -154,7 +154,7 @@ public class AgentITest extends BaseIntegrationTest {
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
-        Registration.RegCheck single= Registration.RegCheck.script("/usr/bin/echo \"sup\"", 10);
+        Registration.RegCheck single= Registration.RegCheck.args(Collections.singletonList("/usr/bin/echo \"sup\""), 10);
 
         List<Registration.RegCheck> regChecks = ImmutableList.of(
                 Registration.RegCheck.http("http://localhost:8080/health", 10));

--- a/src/itest/java/com/orbitz/consul/CatalogITest.java
+++ b/src/itest/java/com/orbitz/consul/CatalogITest.java
@@ -215,7 +215,7 @@ public class CatalogITest extends BaseIntegrationTest {
 
         String serviceName = UUID.randomUUID().toString();
         String serviceId = createAutoDeregisterServiceId();
-        client.agentClient().register(20001, 20, serviceName, serviceId);
+        client.agentClient().register(20001, 20, serviceName, serviceId, Collections.emptyList(), Collections.emptyMap());
 
         CompletableFuture<Map<String, List<String>>> cf = new CompletableFuture<>();
         catalogClient.getServices(QueryOptions.BLANK, callbackFuture(cf));
@@ -231,7 +231,7 @@ public class CatalogITest extends BaseIntegrationTest {
 
         String serviceName = UUID.randomUUID().toString();
         String serviceId = createAutoDeregisterServiceId();
-        client.agentClient().register(20001, 20, serviceName, serviceId);
+        client.agentClient().register(20001, 20, serviceName, serviceId, Collections.emptyList(), Collections.emptyMap());
 
         CompletableFuture<List<CatalogService>> cf = new CompletableFuture<>();
         catalogClient.getService(serviceName, QueryOptions.BLANK, callbackFuture(cf));

--- a/src/itest/java/com/orbitz/consul/PreparedQueryITest.java
+++ b/src/itest/java/com/orbitz/consul/PreparedQueryITest.java
@@ -1,5 +1,6 @@
 package com.orbitz.consul;
 
+import java.util.Collections;
 import java.util.Optional;
 import com.google.common.net.HostAndPort;
 import com.orbitz.consul.model.query.ImmutablePreparedQuery;
@@ -19,7 +20,7 @@ public class PreparedQueryITest {
         String service = UUID.randomUUID().toString();
         String query = UUID.randomUUID().toString();
         Consul consul = Consul.builder().withHostAndPort(HostAndPort.fromParts("192.168.99.100", 8500)).build();
-        consul.agentClient().register(8080, 10000L, service, service + "1");
+        consul.agentClient().register(8080, 10000L, service, service + "1", Collections.emptyList(), Collections.emptyMap());
         PreparedQueryClient preparedQueryClient = consul.preparedQueryClient();
 
         PreparedQuery preparedQuery = ImmutablePreparedQuery.builder()

--- a/src/main/java/com/orbitz/consul/AgentClient.java
+++ b/src/main/java/com/orbitz/consul/AgentClient.java
@@ -96,24 +96,41 @@ public class AgentClient extends BaseClient {
      * @deprecated use {@link #register(int, String, long, String, String, List, Map)} instead
      */
     @Deprecated
-    public void register(int port, String script, long interval, String name, String id, String... tags) {
-        register(port, script, interval, name, id, Lists.newArrayList(tags), Collections.emptyMap());
+    public void register(int port, String args, long interval, String name, String id, String... tags) {
+        register(port, args, interval, name, id, Lists.newArrayList(tags), Collections.emptyMap());
     }
 
     /**
      * Registers the client as a service with Consul with a script based check.
      *
      * @param port     The public facing port of the service to register with Consul.
-     * @param script   Health script for Consul to use.
+     * @param args     Specifies command argument to run to update the status of the check..
      * @param interval Health script run interval in seconds.
      * @param name     Service name to register.
      * @param id       Service id to register.
      * @param tags     Tags to register with.
      * @param meta     Meta to register with.
      */
-    public void register(int port, String script, long interval, String name, String id,
+    public void register(int port, String args, long interval, String name, String id,
                          List<String> tags, Map<String, String> meta) {
-        Registration.RegCheck check = Registration.RegCheck.script(script, interval);
+        Registration.RegCheck check = Registration.RegCheck.args(Collections.singletonList(args), interval);
+        register(port, check, name, id, tags, meta);
+    }
+
+    /**
+     * Registers the client as a service with Consul with a script based check.
+     *
+     * @param port     The public facing port of the service to register with Consul.
+     * @param args     Specifies command argument to run to update the status of the check..
+     * @param interval Health script run interval in seconds.
+     * @param name     Service name to register.
+     * @param id       Service id to register.
+     * @param tags     Tags to register with.
+     * @param meta     Meta to register with.
+     */
+    public void register(int port, List<String> args, long interval, String name, String id,
+                         List<String> tags, Map<String, String> meta) {
+        Registration.RegCheck check = Registration.RegCheck.args(args, interval);
         register(port, check, name, id, tags, meta);
     }
 
@@ -303,18 +320,39 @@ public class AgentClient extends BaseClient {
      *
      * @param checkId  The Check ID to use.  Must be unique for the Agent.
      * @param name     The Check Name.
-     * @param script   Health script for Consul to use.
+     * @param args     Health script for Consul to use.
      * @param interval Health script run interval in seconds.
      * @param notes    Human readable notes.  Not used by Consul.
      */
-    public void registerCheck(String checkId, String name, String script, long interval, String notes) {
+    public void registerCheck(String checkId, String name, List<String> args, long interval, String notes) {
         Check check = ImmutableCheck.builder()
             .id(checkId)
             .name(name)
-            .script(script)
+            .args(args)
             .interval(String.format("%ss", interval))
             .notes(Optional.ofNullable(notes))
             .build();
+
+        registerCheck(check);
+    }
+
+    /**
+     * Registers a script Health Check with the Agent.
+     *
+     * @param checkId  The Check ID to use.  Must be unique for the Agent.
+     * @param name     The Check Name.
+     * @param args     Specifies command argument to run to update the status of the check.
+     * @param interval Health script run interval in seconds.
+     * @param notes    Human readable notes.  Not used by Consul.
+     */
+    public void registerCheck(String checkId, String name, String args, long interval, String notes) {
+        Check check = ImmutableCheck.builder()
+                .id(checkId)
+                .name(name)
+                .args(Collections.singletonList(args))
+                .interval(String.format("%ss", interval))
+                .notes(Optional.ofNullable(notes))
+                .build();
 
         registerCheck(check);
     }

--- a/src/main/java/com/orbitz/consul/AgentClient.java
+++ b/src/main/java/com/orbitz/consul/AgentClient.java
@@ -1,7 +1,6 @@
 package com.orbitz.consul;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
 import com.orbitz.consul.config.ClientConfig;
 import com.orbitz.consul.model.State;
@@ -70,14 +69,6 @@ public class AgentClient extends BaseClient {
     }
 
     /**
-     * @deprecated use {@link #register(int, long, String, String, List, Map)} instead
-     */
-    @Deprecated
-    public void register(int port, long ttl, String name, String id, String... tags) {
-        register(port, ttl, name, id, Lists.newArrayList(tags), Collections.emptyMap());
-    }
-
-    /**
      * Registers the client as a service with Consul with a ttl check.
      *
      * @param port The public facing port of the service to register with Consul.
@@ -90,14 +81,6 @@ public class AgentClient extends BaseClient {
     public void register(int port, long ttl, String name, String id, List<String> tags, Map<String, String> meta) {
         Registration.RegCheck check = Registration.RegCheck.ttl(ttl);
         register(port, check, name, id, tags, meta);
-    }
-
-    /**
-     * @deprecated use {@link #register(int, String, long, String, String, List, Map)} instead
-     */
-    @Deprecated
-    public void register(int port, String args, long interval, String name, String id, String... tags) {
-        register(port, args, interval, name, id, Lists.newArrayList(tags), Collections.emptyMap());
     }
 
     /**
@@ -135,14 +118,6 @@ public class AgentClient extends BaseClient {
     }
 
     /**
-     * @deprecated use {@link #register(int, URL, long, String, String, List, Map)} instead
-     */
-    @Deprecated
-    public void register(int port, URL http, long interval, String name, String id, String... tags) {
-        register(port, http, interval, name, id, Lists.newArrayList(tags), Collections.emptyMap());
-    }
-
-    /**
      * Registers the client as a service with Consul with an http based check
      *
      * @param port     The public facing port of the service to register with Consul.
@@ -160,14 +135,6 @@ public class AgentClient extends BaseClient {
     }
 
     /**
-     * @deprecated use {@link #register(int, HostAndPort, long, String, String, List, Map)} instead
-     */
-    @Deprecated
-    public void register(int port, HostAndPort tcp, long interval, String name, String id, String... tags) {
-        register(port, tcp, interval, name, id, Lists.newArrayList(tags), Collections.emptyMap());
-    }
-
-    /**
      * Registers the client as a service with Consul with a TCP based check
      *
      * @param port     The public facing port of the service to register with Consul.
@@ -182,13 +149,6 @@ public class AgentClient extends BaseClient {
                          List<String> tags, Map<String, String> meta) {
         Registration.RegCheck check = Registration.RegCheck.tcp(tcp.toString(), interval);
         register(port, check, name, id, tags, meta);
-    }
-
-    /**
-     * @deprecated use {@link #register(int, Registration.RegCheck, String, String, List, Map)} instead
-     */
-    public void register(int port, Registration.RegCheck check, String name, String id, String... tags) {
-        register(port, check, name, id, Lists.newArrayList(tags), Collections.emptyMap());
     }
 
     /**
@@ -214,14 +174,6 @@ public class AgentClient extends BaseClient {
                 .build();
 
         register(registration);
-    }
-
-    /**
-     * @deprecated use {@link #register(int, List, String, String, List, Map)} instead
-     */
-    @Deprecated
-    public void register(int port, List<Registration.RegCheck> checks, String name, String id, String... tags) {
-        register(port, checks, name, id, Lists.newArrayList(tags), Collections.emptyMap());
     }
 
     /**

--- a/src/main/java/com/orbitz/consul/model/agent/Check.java
+++ b/src/main/java/com/orbitz/consul/model/agent/Check.java
@@ -30,8 +30,8 @@ public abstract class Check {
     @JsonProperty("Output")
     public abstract Optional<String> getOutput();
 
-    @JsonProperty("Script")
-    public abstract Optional<String> getScript();
+    @JsonProperty("Args")
+    public abstract Optional<List<String>> getArgs();
 
     @JsonProperty("Interval")
     public abstract Optional<String> getInterval();
@@ -65,12 +65,12 @@ public abstract class Check {
     protected void validate() {
 
         checkState(getHttp().isPresent() || getTtl().isPresent()
-            || getScript().isPresent() || getTcp().isPresent() || getGrpc().isPresent(),
-                "Check must specify either http, tcp, ttl, grpc or script");
+            || getArgs().isPresent() || getTcp().isPresent() || getGrpc().isPresent(),
+                "Check must specify either http, tcp, ttl, grpc or args");
 
-        if (getHttp().isPresent() || getScript().isPresent() || getTcp().isPresent() || getGrpc().isPresent()) {
+        if (getHttp().isPresent() || getArgs().isPresent() || getTcp().isPresent() || getGrpc().isPresent()) {
             checkState(getInterval().isPresent(),
-                    "Interval must be set if check type is http, tcp, grpc or script");
+                    "Interval must be set if check type is http, tcp, grpc or args");
         }
 
     }

--- a/src/main/java/com/orbitz/consul/model/agent/Registration.java
+++ b/src/main/java/com/orbitz/consul/model/agent/Registration.java
@@ -55,8 +55,8 @@ public abstract class Registration {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public abstract static class RegCheck {
 
-        @JsonProperty("Script")
-        public abstract Optional<String> getScript();
+        @JsonProperty("Args")
+        public abstract Optional<List<String>> getArgs();
 
         @JsonProperty("Interval")
         public abstract Optional<String> getInterval();
@@ -98,27 +98,27 @@ public abstract class Registration {
                     .build();
         }
 
-        public static RegCheck script(String script, long interval) {
+        public static RegCheck args(List<String> args, long interval) {
             return ImmutableRegCheck
                     .builder()
-                    .script(script)
+                    .args(args)
                     .interval(String.format("%ss", interval))
                     .build();
         }
 
-        public static RegCheck script(String script, long interval, long timeout) {
+        public static RegCheck args(List<String> args, long interval, long timeout) {
             return ImmutableRegCheck
                     .builder()
-                    .script(script)
+                    .args(args)
                     .interval(String.format("%ss", interval))
                     .timeout(String.format("%ss", timeout))
                     .build();
         }
         
-        public static RegCheck script(String script, long interval, long timeout, String notes) {
+        public static RegCheck args(List<String> args, long interval, long timeout, String notes) {
             return ImmutableRegCheck
                     .builder()
-                    .script(script)
+                    .args(args)
                     .interval(String.format("%ss", interval))
                     .timeout(String.format("%ss", timeout))
                     .notes(notes)
@@ -196,12 +196,12 @@ public abstract class Registration {
         protected void validate() {
 
             checkState(getHttp().isPresent() || getTtl().isPresent()
-                || getScript().isPresent() || getTcp().isPresent() || getGrpc().isPresent(),
-                    "Check must specify either http, tcp, ttl, grpc or script");
+                || getArgs().isPresent() || getTcp().isPresent() || getGrpc().isPresent(),
+                    "Check must specify either http, tcp, ttl, grpc or args");
 
-            if (getHttp().isPresent() || getScript().isPresent() || getTcp().isPresent() || getGrpc().isPresent()) {
+            if (getHttp().isPresent() || getArgs().isPresent() || getTcp().isPresent() || getGrpc().isPresent()) {
                 checkState(getInterval().isPresent(),
-                        "Interval must be set if check type is http, tcp, grpc or script");
+                        "Interval must be set if check type is http, tcp, grpc or args");
             }
         }
 

--- a/src/test/java/com/orbitz/consul/model/agent/CheckTest.java
+++ b/src/test/java/com/orbitz/consul/model/agent/CheckTest.java
@@ -1,10 +1,12 @@
 package com.orbitz.consul.model.agent;
 
+import com.google.common.collect.Lists;
 import org.junit.Test;
 
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class CheckTest {
 
@@ -36,12 +38,25 @@ public class CheckTest {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void buildingCheckWithScriptThrowsIfMissingInterval() {
+    public void buildingCheckWithArgsThrowsIfMissingInterval() {
         ImmutableCheck.builder()
                 .id("id")
-                .script("/bin/echo \"hi\"")
+                .args(Collections.singletonList("/bin/echo \"hi\""))
                 .name("name")
                 .build();
+    }
+
+    @Test
+    public void severalArgsCanBeAddedToCheck() {
+        Check check = ImmutableCheck.builder()
+                .id("id")
+                .args(Lists.newArrayList("/bin/echo \"hi\"", "/bin/echo \"hello\""))
+                .interval("1s")
+                .name("name")
+                .build();
+
+        assertTrue("Args should be present in check", check.getArgs().isPresent());
+        assertEquals("Check should contain 2 args", 2, check.getArgs().get().size());
     }
 
     @Test


### PR DESCRIPTION
As stated in issue #340, the current code allows to set a script in checks as a single string whereas in current version of Consul (and for allo above 1.0) it has been replaced by a list of string. Also, the name of the property in the JSON changed from `script` to `args`.