### PR TITLE
[Fix] Enable setting several datacenters in prepared query failover

### DIFF
--- a/src/main/java/com/orbitz/consul/model/query/Failover.java
+++ b/src/main/java/com/orbitz/consul/model/query/Failover.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
 import java.util.Optional;
 
 @org.immutables.value.Value.Immutable
@@ -16,5 +19,6 @@ public abstract class Failover {
     public abstract Optional<Integer> getNearestN();
 
     @JsonProperty("Datacenters")
-    public abstract Optional<String> datacenters();
+    @JsonDeserialize(as = ImmutableList.class, contentAs = String.class)
+    public abstract Optional<List<String>> datacenters();
 }

--- a/src/test/java/com/orbitz/consul/model/query/FailoverTest.java
+++ b/src/test/java/com/orbitz/consul/model/query/FailoverTest.java
@@ -1,0 +1,29 @@
+package com.orbitz.consul.model.query;
+
+import com.google.common.collect.Lists;
+import org.junit.Test;
+
+public class FailoverTest {
+
+    @Test
+    public void creatingFailoverWithDatacentersIsValid() {
+        ImmutableFailover.builder()
+                .datacenters(Lists.newArrayList("dc1", "dc2"))
+                .build();
+    }
+
+    @Test
+    public void creatingFailoverWithNearestIsValid() {
+        ImmutableFailover.builder()
+                .nearestN(2)
+                .build();
+    }
+
+    @Test
+    public void creatingFailoverWithNearestAndDatacentersIsValid() {
+        ImmutableFailover.builder()
+                .datacenters(Lists.newArrayList("dc1", "dc2"))
+                .nearestN(2)
+                .build();
+    }
+}


### PR DESCRIPTION
As stated in #274, a string is not a valid input for the datacenters list.
Use a list of strings instead.
See https://www.consul.io/api/query.html#failover