### PR TITLE
Add support for non available lan address

### DIFF
--- a/src/main/java/com/orbitz/consul/model/catalog/TaggedAddresses.java
+++ b/src/main/java/com/orbitz/consul/model/catalog/TaggedAddresses.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
+import java.util.Optional;
+
 @Value.Immutable
 @JsonSerialize(as = ImmutableTaggedAddresses.class)
 @JsonDeserialize(as = ImmutableTaggedAddresses.class)
@@ -17,5 +19,5 @@ public abstract class TaggedAddresses {
     public abstract String getWan();
 
     @JsonProperty("lan")
-    public abstract String getLan();
+    public abstract Optional<String> getLan();
 }

--- a/src/test/java/com/orbitz/consul/model/catalog/TaggedAddressesTest.java
+++ b/src/test/java/com/orbitz/consul/model/catalog/TaggedAddressesTest.java
@@ -1,0 +1,29 @@
+package com.orbitz.consul.model.catalog;
+
+import org.junit.Test;
+
+public class TaggedAddressesTest {
+
+    @Test
+    public void buildingTaggedAddressWithAllAttributesShouldSucceed() {
+        ImmutableTaggedAddresses.builder()
+                .lan("127.0.0.1")
+                .wan("172.217.17.110")
+                .build();
+    }
+
+    @Test
+    public void buildingTaggedAddressWithoutLanAddressShouldSucceed() {
+        ImmutableTaggedAddresses.builder()
+                .wan("172.217.17.110")
+                .build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void buildingTaggedAddressWithoutWanAddressShouldThrow() {
+        ImmutableTaggedAddresses.builder()
+                .lan("127.0.0.1")
+                .build();
+    }
+
+}


### PR DESCRIPTION
As stated in issue #329, some users are using Consul prior to 0.6.
Lan address was added in Consul 0.7.
Lower versions of Consul require this field to be optional.
Note that it does not have any impact on recent Consul versions.