### PR TITLE
[Fix] Agent/force-leave does not work

### DIFF
--- a/src/main/java/com/orbitz/consul/AgentClient.java
+++ b/src/main/java/com/orbitz/consul/AgentClient.java
@@ -454,7 +454,7 @@ public class AgentClient extends BaseClient {
      * @param node
      */
     public void forceLeave(String node) {
-        http.handle(api.forceLeave());
+        http.handle(api.forceLeave(node));
     }
 
     /**
@@ -663,8 +663,8 @@ public class AgentClient extends BaseClient {
         @GET("agent/members")
         Call<List<Member>> getMembers();
 
-        @PUT("agent/force-leave")
-        Call<Void> forceLeave();
+        @PUT("agent/force-leave/{node}")
+        Call<Void> forceLeave(@Path("string") String node);
 
         @PUT("agent/check/{state}/{checkId}")
         Call<Void> check(@Path("state") String state,


### PR DESCRIPTION
As reported in #351, calling HTTP endpoint "agent/force-leave" leads to an error due to the fact that the PUT request becomes a GET request.

This was due to the fact that the `node` parameter was missing in the endpoint configuration. The HTTP endpoint "agent/force-leave" does not exist and Consul respond with "301 Moved Permanently v1/agent/force-leave/". The request was then redirected to this new url by OkHttp client. This redirection is always done with GET and Consul rejects it once more (even though the URL is valid).

The API documentation of Consul HTTP API (hashicorp) is out-of-date.
To see the actual endpoint see:
 - https://github.com/hashicorp/consul/blob/master/agent/http_oss.go#L25
 - https://github.com/hashicorp/consul/blob/master/agent/agent_endpoint.go#L323
 - https://github.com/hashicorp/consul/blob/master/agent/agent.go#L1442

I've create a PR to update the documentation (see https://github.com/hashicorp/consul/pull/4542)