### PR TITLE
Add Multiple Host Failover Support To Consul Client

### DIFF
--- a/src/itest/java/com/orbitz/consul/failover/FailoverTest.java
+++ b/src/itest/java/com/orbitz/consul/failover/FailoverTest.java
@@ -1,0 +1,50 @@
+package com.orbitz.consul.failover;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.google.common.net.HostAndPort;
+import com.orbitz.consul.Consul;
+import com.orbitz.consul.Consul.Builder;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.naming.TestCaseName;
+
+@RunWith(JUnitParamsRunner.class)
+public class FailoverTest {
+
+	
+	@Test
+	@TestCaseName("Failover Check")
+	public void TestFailover() throws InterruptedException {
+
+		// Create a set of targets
+		final Collection<HostAndPort> targets = new ArrayList<>();
+		targets.add(HostAndPort.fromParts("1.2.3.4", 8500));
+		targets.add(HostAndPort.fromParts("localhost", 8500));
+		
+		// Create our consul instance
+		Builder c = Consul.builder();
+		c.withMultipleHostAndPort(targets, 5000);
+		c.withConnectTimeoutMillis(500);
+		
+		// Create the client
+		Consul client = c.build();
+		
+		// Get the peers (should fail through 1.2.3.4 into localhost)
+		List<String> peers = client.statusClient().getPeers();
+		assertNotNull(peers);
+		
+		Thread.sleep(5000);
+		
+		// Get the peers( should fail through 1.2.3.4 into localhost since the 5000 millisecond blacklist has expired)
+		peers = client.statusClient().getPeers();
+		assertNotNull(peers);
+	}
+}

--- a/src/main/java/com/orbitz/consul/Consul.java
+++ b/src/main/java/com/orbitz/consul/Consul.java
@@ -1,5 +1,24 @@
 package com.orbitz.consul;
 
+import java.net.ConnectException;
+import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -11,26 +30,16 @@ import com.orbitz.consul.monitoring.ClientEventCallback;
 import com.orbitz.consul.util.Jackson;
 import com.orbitz.consul.util.bookend.ConsulBookend;
 import com.orbitz.consul.util.bookend.ConsulBookendInterceptor;
+
 import okhttp3.Dispatcher;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.Response;
 import okhttp3.internal.Util;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.X509TrustManager;
-import java.net.MalformedURLException;
-import java.net.Proxy;
-import java.net.URL;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Client for interacting with the Consul HTTP API.
@@ -255,6 +264,9 @@ public class Consul {
      * Builder for {@link Consul} client objects.
      */
     public static class Builder {
+    	private Map<Integer, Instant> failoverBlacklist;
+		private long failoverBlacklistTimeout;
+		private Collection<URL> failoverURLs;
         private URL url;
         private SSLContext sslContext;
         private X509TrustManager trustManager;
@@ -265,6 +277,7 @@ public class Consul {
         private Interceptor aclTokenInterceptor;
         private Interceptor headerInterceptor;
         private Interceptor consulBookendInterceptor;
+		private Interceptor consulFailoverInterceptor;
         private Long connectTimeoutMillis;
         private Long readTimeoutMillis;
         private Long writeTimeoutMillis;
@@ -412,6 +425,129 @@ public class Consul {
 
             return this;
         }
+        
+        /**
+		 * Sets the list of hosts to contact if the current request target is
+		 * unavailable. When the call to a particular URL fails for any reason, the next {@link HostAndPort} specified
+		 * is used to retry the request. This will continue until all urls are exhuasted.
+		 * 
+		 * @param hostAndPort A collection of {@link HostAndPort} that define the list of Consul agent addresses to use.
+		 * @param blacklistTimeInMillis The timeout (in milliseconds) to blacklist a particular {@link HostAndPort} before trying to use it again.
+		 * @return The builder.
+		 */
+		public Builder withMultipleHostAndPort(Collection<HostAndPort> hostAndPort, long blacklistTimeInMillis) {
+			Preconditions.checkArgument(blacklistTimeInMillis >= 0, "Negative Value");
+			Preconditions.checkArgument(hostAndPort.size() >= 2, "Minimum of 2 addresses are required");
+
+			// Create the set of failover urls
+			this.failoverURLs = hostAndPort.stream().map((HostAndPort hop) -> {
+				try {
+					return new URL("http", hop.getHost(), hop.getPort(), "");
+				} catch (MalformedURLException e) {
+					throw new RuntimeException(e);
+				}
+			}).collect(Collectors.toList());
+
+			// Set the initial url to the first URL in the stream
+			this.url = this.failoverURLs.stream().findFirst().get();
+
+			// Set the timeout
+			this.failoverBlacklistTimeout = blacklistTimeInMillis;
+
+			// Create the interceptor
+			consulFailoverInterceptor = chain -> {
+				
+				
+				Response originalResponse = null;
+				boolean needRetry = false;
+				
+				// Do the original request
+				Request originalRequest = chain.request();
+				
+				// Initialize the blacklist map
+				if (failoverBlacklist == null)
+					failoverBlacklist = new HashMap<>();
+
+				// Hash the initial request, otherwise the original URL would always be queried,
+				// blacklisted or not
+				final int requestHash = String.format("%s:%d", originalRequest.url().host(), originalRequest.url().port()).hashCode();
+
+				// Find the original response
+				try {
+
+					// If the original query was not blacklisted, continue with it
+					if (!failoverBlacklist.containsKey(requestHash)) {
+						originalResponse = chain.proceed(chain.request());
+						
+						// Possibly introduce logic to stop retrying 403, but this could break
+						// cross-cluster failovers (one which has ACL support and one which does not)
+						needRetry = !originalResponse.isSuccessful();
+					} else {
+						needRetry = true;
+					}
+				} catch (ConnectException crex) {
+					needRetry = true;
+				}
+
+				if (needRetry) {
+
+					// Add the current hashcode of the username and port to the blacklist map. This
+					// will allow us to temporarily
+					// blacklist a particular combination for a set
+					failoverBlacklist.put(requestHash, Instant.now());
+
+					HttpUrl target = null;
+					int targetHash = -1;
+
+					// Find the appropriate urls
+					for (URL url : failoverURLs) {
+
+						// Create the blacklist key
+						targetHash = url.hashCode();
+
+						// Determine if this host is allowed to be a retry candidate
+						if (failoverBlacklist.containsKey(targetHash)) {
+
+							// Find out when the particular key was blacklisted
+							Instant blacklistedWhen = failoverBlacklist.get(targetHash);
+
+							// If the duration to blacklist the host and port combination has elapsed,
+							// remove it from the set
+							if (Duration.between(blacklistedWhen, Instant.now())
+									.toMillis() >= failoverBlacklistTimeout) {
+								failoverBlacklist.remove(targetHash);
+							} else {
+								continue;
+							}
+						}
+						// Construct an intermediate http url object representing the new URL we wish to
+						// query
+						HttpUrl intermediate = HttpUrl.get(url);
+
+						// New target url
+						target = originalRequest.url().newBuilder().host(intermediate.host()).port(intermediate.port())
+								.build();
+						
+						// Attempt to return the new response
+						try {
+							return chain.proceed(originalRequest.newBuilder().url(target).build());
+						} catch (ConnectException | ConsulException ex) {
+							failoverBlacklist.put(targetHash, Instant.now());
+							continue;
+						}
+					}
+
+					// The only way to retry is to have a new URL
+					if (target == null)
+						throw new ConsulException("No suitable targets available");
+
+				}
+
+				return originalResponse;
+			};
+
+			return this;
+		}
 
         /**
          * Sets the URL from a string.
@@ -646,6 +782,10 @@ public class Consul {
             if (consulBookendInterceptor != null) {
                 builder.addInterceptor(consulBookendInterceptor);
             }
+            
+			if (consulFailoverInterceptor != null) {
+				builder.addInterceptor(consulFailoverInterceptor);
+			}
 
             if (sslContext != null && trustManager != null) {
                 builder.sslSocketFactory(sslContext.getSocketFactory(), trustManager);

--- a/src/main/java/com/orbitz/consul/Consul.java
+++ b/src/main/java/com/orbitz/consul/Consul.java
@@ -42,20 +42,20 @@ import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
 /**
- * Client for interacting with the Consul HTTP API.
- *
- * @author rfast
- */
+* Client for interacting with the Consul HTTP API.
+*
+* @author rfast
+*/
 public class Consul {
 
     /**
-     * Default Consul HTTP API host.
-     */
+    * Default Consul HTTP API host.
+    */
     public static final String DEFAULT_HTTP_HOST = "localhost";
 
     /**
-     * Default Consul HTTP API port.
-     */
+    * Default Consul HTTP API port.
+    */
     public static final int DEFAULT_HTTP_PORT = 8500;
 
     private final AgentClient agentClient;
@@ -75,16 +75,16 @@ public class Consul {
     private final OkHttpClient okHttpClient;
 
     /**
-     * Private constructor.
-     *
-     */
+    * Private constructor.
+    *
+    */
     private Consul(AgentClient agentClient, HealthClient healthClient,
-                   KeyValueClient keyValueClient, CatalogClient catalogClient,
-                   StatusClient statusClient, SessionClient sessionClient,
-                   EventClient eventClient, PreparedQueryClient preparedQueryClient,
-                   CoordinateClient coordinateClient, OperatorClient operatorClient,
-                   ExecutorService executorService, AclClient aclClient,
-                   SnapshotClient snapshotClient, OkHttpClient okHttpClient) {
+                KeyValueClient keyValueClient, CatalogClient catalogClient,
+                StatusClient statusClient, SessionClient sessionClient,
+                EventClient eventClient, PreparedQueryClient preparedQueryClient,
+                CoordinateClient coordinateClient, OperatorClient operatorClient,
+                ExecutorService executorService, AclClient aclClient,
+                SnapshotClient snapshotClient, OkHttpClient okHttpClient) {
         this.agentClient = agentClient;
         this.healthClient = healthClient;
         this.keyValueClient = keyValueClient;
@@ -102,171 +102,171 @@ public class Consul {
     }
 
     /**
-     * Destroys the Object internal state.
-     */
+    * Destroys the Object internal state.
+    */
     public void destroy() {
         this.okHttpClient.dispatcher().cancelAll();
         this.executorService.shutdownNow();
     }
 
     /**
-     * Get the Agent HTTP client.
-     * <p>
-     * /v1/agent
-     *
-     * @return The Agent HTTP client.
-     */
+    * Get the Agent HTTP client.
+    * <p>
+    * /v1/agent
+    *
+    * @return The Agent HTTP client.
+    */
     public AgentClient agentClient() {
         return agentClient;
     }
 
     /**
-     * Get the ACL HTTP client.
-     * <p>
-     * /v1/acl
-     *
-     * @return The ACL HTTP client.
-     */
+    * Get the ACL HTTP client.
+    * <p>
+    * /v1/acl
+    *
+    * @return The ACL HTTP client.
+    */
     public AclClient aclClient() {
         return aclClient;
     }
 
     /**
-     * Get the Catalog HTTP client.
-     * <p>
-     * /v1/catalog
-     *
-     * @return The Catalog HTTP client.
-     */
+    * Get the Catalog HTTP client.
+    * <p>
+    * /v1/catalog
+    *
+    * @return The Catalog HTTP client.
+    */
     public CatalogClient catalogClient() {
         return catalogClient;
     }
 
     /**
-     * Get the Health HTTP client.
-     * <p>
-     * /v1/health
-     *
-     * @return The Health HTTP client.
-     */
+    * Get the Health HTTP client.
+    * <p>
+    * /v1/health
+    *
+    * @return The Health HTTP client.
+    */
     public HealthClient healthClient() {
         return healthClient;
     }
 
     /**
-     * Get the Key/Value HTTP client.
-     * <p>
-     * /v1/kv
-     *
-     * @return The Key/Value HTTP client.
-     */
+    * Get the Key/Value HTTP client.
+    * <p>
+    * /v1/kv
+    *
+    * @return The Key/Value HTTP client.
+    */
     public KeyValueClient keyValueClient() {
         return keyValueClient;
     }
 
     /**
-     * Get the Status HTTP client.
-     * <p>
-     * /v1/status
-     *
-     * @return The Status HTTP client.
-     */
+    * Get the Status HTTP client.
+    * <p>
+    * /v1/status
+    *
+    * @return The Status HTTP client.
+    */
     public StatusClient statusClient() {
         return statusClient;
     }
 
     /**
-     * Get the SessionInfo HTTP client.
-     * <p>
-     * /v1/session
-     *
-     * @return The SessionInfo HTTP client.
-     */
+    * Get the SessionInfo HTTP client.
+    * <p>
+    * /v1/session
+    *
+    * @return The SessionInfo HTTP client.
+    */
     public SessionClient sessionClient() {
         return sessionClient;
     }
 
     /**
-     * Get the Event HTTP client.
-     * <p>
-     * /v1/event
-     *
-     * @return The Event HTTP client.
-     */
+    * Get the Event HTTP client.
+    * <p>
+    * /v1/event
+    *
+    * @return The Event HTTP client.
+    */
     public EventClient eventClient() {
         return eventClient;
     }
 
     /**
-     * Get the Prepared Query HTTP client.
-     * <p>
-     * /v1/query
-     *
-     * @return The Prepared Query HTTP client.
-     */
+    * Get the Prepared Query HTTP client.
+    * <p>
+    * /v1/query
+    *
+    * @return The Prepared Query HTTP client.
+    */
     public PreparedQueryClient preparedQueryClient() {
         return preparedQueryClient;
     }
 
     /**
-     * Get the Coordinate HTTP client.
-     * <p>
-     * /v1/coordinate
-     *
-     * @return The Coordinate HTTP client.
-     */
+    * Get the Coordinate HTTP client.
+    * <p>
+    * /v1/coordinate
+    *
+    * @return The Coordinate HTTP client.
+    */
     public CoordinateClient coordinateClient() {
         return coordinateClient;
     }
 
     /**
-     * Get the Operator HTTP client.
-     * <p>
-     * /v1/operator
-     *
-     * @return The Operator HTTP client.
-     */
+    * Get the Operator HTTP client.
+    * <p>
+    * /v1/operator
+    *
+    * @return The Operator HTTP client.
+    */
     public OperatorClient operatorClient() {
         return operatorClient;
     }
 
     /**
-     * Get the Snapshot HTTP client.
-     * <p>
-     * /v1/snapshot
-     *
-     * @return The Snapshot HTTP client.
-     */
+    * Get the Snapshot HTTP client.
+    * <p>
+    * /v1/snapshot
+    *
+    * @return The Snapshot HTTP client.
+    */
     public SnapshotClient snapshotClient() {
         return snapshotClient;
     }
 
     /**
-     * Creates a new {@link Builder} object.
-     *
-     * @return A new Consul builder.
-     */
+    * Creates a new {@link Builder} object.
+    *
+    * @return A new Consul builder.
+    */
     public static Builder builder() {
         return new Builder();
     }
 
     /**
-     * Used to create a default Consul client.
-     *
-     * @return A default {@link Consul} client.
-     */
+    * Used to create a default Consul client.
+    *
+    * @return A default {@link Consul} client.
+    */
     @VisibleForTesting
     public static Consul newClient() {
         return builder().build();
     }
 
     /**
-     * Builder for {@link Consul} client objects.
-     */
+    * Builder for {@link Consul} client objects.
+    */
     public static class Builder {
-    	private Map<Integer, Instant> failoverBlacklist;
-		private long failoverBlacklistTimeout;
-		private Collection<URL> failoverURLs;
+        private Map<Integer, Instant> failoverBlacklist;
+        private long failoverBlacklistTimeout;
+        private Collection<URL> failoverURLs;
         private URL url;
         private SSLContext sslContext;
         private X509TrustManager trustManager;
@@ -277,7 +277,7 @@ public class Consul {
         private Interceptor aclTokenInterceptor;
         private Interceptor headerInterceptor;
         private Interceptor consulBookendInterceptor;
-		private Interceptor consulFailoverInterceptor;
+        private Interceptor consulFailoverInterceptor;
         private Long connectTimeoutMillis;
         private Long readTimeoutMillis;
         private Long writeTimeoutMillis;
@@ -294,18 +294,18 @@ public class Consul {
         }
 
         /**
-         * Constructs a new builder.
-         */
+        * Constructs a new builder.
+        */
         Builder() {
 
         }
 
         /**
-         * Sets the URL from a {@link URL} object.
-         *
-         * @param url The Consul agent URL.
-         * @return The builder.
-         */
+        * Sets the URL from a {@link URL} object.
+        *
+        * @param url The Consul agent URL.
+        * @return The builder.
+        */
         public Builder withUrl(URL url) {
             this.url = url;
 
@@ -313,11 +313,11 @@ public class Consul {
         }
 
         /**
-         * Instructs the builder that the AgentClient should attempt a ping before returning the Consul instance
-         *
-         * @param ping Whether the ping should be done or not
-         * @return The builder.
-         */
+        * Instructs the builder that the AgentClient should attempt a ping before returning the Consul instance
+        *
+        * @param ping Whether the ping should be done or not
+        * @return The builder.
+        */
         public Builder withPing(boolean ping) {
             this.ping = ping;
 
@@ -325,12 +325,12 @@ public class Consul {
         }
 
         /**
-         * Sets the username and password to be used for basic authentication
-         *
-         * @param username the value of the username
-         * @param password the value of the password
-         * @return The builder.
-         */
+        * Sets the username and password to be used for basic authentication
+        *
+        * @param username the value of the username
+        * @param password the value of the password
+        * @return The builder.
+        */
         public Builder withBasicAuth(String username, String password) {
             String credentials = username + ":" + password;
             final String basic = "Basic " + BaseEncoding.base64().encode(credentials.getBytes());
@@ -349,11 +349,11 @@ public class Consul {
         }
 
         /**
-         * Sets the ACL token to be used with Consul
-         *
-         * @param token the value of the token
-         * @return The builder.
-         */
+        * Sets the ACL token to be used with Consul
+        *
+        * @param token the value of the token
+        * @return The builder.
+        */
         public Builder withAclToken(final String token) {
             aclTokenInterceptor = chain -> {
                 Request original = chain.request();
@@ -378,11 +378,11 @@ public class Consul {
         }
 
         /**
-         * Sets headers to be included with each Consul request.
-         *
-         * @param headers Map of headers.
-         * @return The builder.
-         */
+        * Sets headers to be included with each Consul request.
+        *
+        * @param headers Map of headers.
+        * @return The builder.
+        */
         public Builder withHeaders(final Map<String, String> headers) {
             headerInterceptor = chain -> {
                 Request.Builder requestBuilder = chain.request().newBuilder();
@@ -398,12 +398,12 @@ public class Consul {
         }
 
         /**
-         * Attaches a {@link ConsulBookend} to each Consul request. This can be used for gathering
-         * metrics timings or debugging. {@see ConsulBookend}
-         *
-         * @param consulBookend The bookend implementation.
-         * @return The builder.
-         */
+        * Attaches a {@link ConsulBookend} to each Consul request. This can be used for gathering
+        * metrics timings or debugging. {@see ConsulBookend}
+        *
+        * @param consulBookend The bookend implementation.
+        * @return The builder.
+        */
         public Builder withConsulBookend(ConsulBookend consulBookend) {
             consulBookendInterceptor = new ConsulBookendInterceptor(consulBookend);
 
@@ -411,11 +411,11 @@ public class Consul {
         }
 
         /**
-         * Sets the URL from a {@link HostAndPort} object.
-         *
-         * @param hostAndPort The Consul agent host and port.
-         * @return The builder.
-         */
+        * Sets the URL from a {@link HostAndPort} object.
+        *
+        * @param hostAndPort The Consul agent host and port.
+        * @return The builder.
+        */
         public Builder withHostAndPort(HostAndPort hostAndPort) {
             try {
                 this.url = new URL("http", hostAndPort.getHost(), hostAndPort.getPort(), "");
@@ -427,134 +427,134 @@ public class Consul {
         }
         
         /**
-		 * Sets the list of hosts to contact if the current request target is
-		 * unavailable. When the call to a particular URL fails for any reason, the next {@link HostAndPort} specified
-		 * is used to retry the request. This will continue until all urls are exhuasted.
-		 * 
-		 * @param hostAndPort A collection of {@link HostAndPort} that define the list of Consul agent addresses to use.
-		 * @param blacklistTimeInMillis The timeout (in milliseconds) to blacklist a particular {@link HostAndPort} before trying to use it again.
-		 * @return The builder.
-		 */
-		public Builder withMultipleHostAndPort(Collection<HostAndPort> hostAndPort, long blacklistTimeInMillis) {
-			Preconditions.checkArgument(blacklistTimeInMillis >= 0, "Negative Value");
-			Preconditions.checkArgument(hostAndPort.size() >= 2, "Minimum of 2 addresses are required");
+        * Sets the list of hosts to contact if the current request target is
+        * unavailable. When the call to a particular URL fails for any reason, the next {@link HostAndPort} specified
+        * is used to retry the request. This will continue until all urls are exhuasted.
+        * 
+        * @param hostAndPort A collection of {@link HostAndPort} that define the list of Consul agent addresses to use.
+        * @param blacklistTimeInMillis The timeout (in milliseconds) to blacklist a particular {@link HostAndPort} before trying to use it again.
+        * @return The builder.
+        */
+        public Builder withMultipleHostAndPort(Collection<HostAndPort> hostAndPort, long blacklistTimeInMillis) {
+            Preconditions.checkArgument(blacklistTimeInMillis >= 0, "Negative Value");
+            Preconditions.checkArgument(hostAndPort.size() >= 2, "Minimum of 2 addresses are required");
 
-			// Create the set of failover urls
-			this.failoverURLs = hostAndPort.stream().map((HostAndPort hop) -> {
-				try {
-					return new URL("http", hop.getHost(), hop.getPort(), "");
-				} catch (MalformedURLException e) {
-					throw new RuntimeException(e);
-				}
-			}).collect(Collectors.toList());
+            // Create the set of failover urls
+            this.failoverURLs = hostAndPort.stream().map((HostAndPort hop) -> {
+                try {
+                    return new URL("http", hop.getHost(), hop.getPort(), "");
+                } catch (MalformedURLException e) {
+                    throw new RuntimeException(e);
+                }
+            }).collect(Collectors.toList());
 
-			// Set the initial url to the first URL in the stream
-			this.url = this.failoverURLs.stream().findFirst().get();
+            // Set the initial url to the first URL in the stream
+            this.url = this.failoverURLs.stream().findFirst().get();
 
-			// Set the timeout
-			this.failoverBlacklistTimeout = blacklistTimeInMillis;
+            // Set the timeout
+            this.failoverBlacklistTimeout = blacklistTimeInMillis;
 
-			// Create the interceptor
-			consulFailoverInterceptor = chain -> {
-				
-				
-				Response originalResponse = null;
-				boolean needRetry = false;
-				
-				// Do the original request
-				Request originalRequest = chain.request();
-				
-				// Initialize the blacklist map
-				if (failoverBlacklist == null)
-					failoverBlacklist = new HashMap<>();
+            // Create the interceptor
+            consulFailoverInterceptor = chain -> {
+                
+                
+                Response originalResponse = null;
+                boolean needRetry = false;
+                
+                // Do the original request
+                Request originalRequest = chain.request();
+                
+                // Initialize the blacklist map
+                if (failoverBlacklist == null)
+                    failoverBlacklist = new HashMap<>();
 
-				// Hash the initial request, otherwise the original URL would always be queried,
-				// blacklisted or not
-				final int requestHash = String.format("%s:%d", originalRequest.url().host(), originalRequest.url().port()).hashCode();
+                // Hash the initial request, otherwise the original URL would always be queried,
+                // blacklisted or not
+                final int requestHash = String.format("%s:%d", originalRequest.url().host(), originalRequest.url().port()).hashCode();
 
-				// Find the original response
-				try {
+                // Find the original response
+                try {
 
-					// If the original query was not blacklisted, continue with it
-					if (!failoverBlacklist.containsKey(requestHash)) {
-						originalResponse = chain.proceed(chain.request());
-						
-						// Possibly introduce logic to stop retrying 403, but this could break
-						// cross-cluster failovers (one which has ACL support and one which does not)
-						needRetry = !originalResponse.isSuccessful();
-					} else {
-						needRetry = true;
-					}
-				} catch (ConnectException crex) {
-					needRetry = true;
-				}
+                    // If the original query was not blacklisted, continue with it
+                    if (!failoverBlacklist.containsKey(requestHash)) {
+                        originalResponse = chain.proceed(chain.request());
+                        
+                        // Possibly introduce logic to stop retrying 403, but this could break
+                        // cross-cluster failovers (one which has ACL support and one which does not)
+                        needRetry = !originalResponse.isSuccessful();
+                    } else {
+                        needRetry = true;
+                    }
+                } catch (ConnectException crex) {
+                    needRetry = true;
+                }
 
-				if (needRetry) {
+                if (needRetry) {
 
-					// Add the current hashcode of the username and port to the blacklist map. This
-					// will allow us to temporarily
-					// blacklist a particular combination for a set
-					failoverBlacklist.put(requestHash, Instant.now());
+                    // Add the current hashcode of the username and port to the blacklist map. This
+                    // will allow us to temporarily
+                    // blacklist a particular combination for a set
+                    failoverBlacklist.put(requestHash, Instant.now());
 
-					HttpUrl target = null;
-					int targetHash = -1;
+                    HttpUrl target = null;
+                    int targetHash = -1;
 
-					// Find the appropriate urls
-					for (URL url : failoverURLs) {
+                    // Find the appropriate urls
+                    for (URL url : failoverURLs) {
 
-						// Create the blacklist key
-						targetHash = url.hashCode();
+                        // Create the blacklist key
+                        targetHash = url.hashCode();
 
-						// Determine if this host is allowed to be a retry candidate
-						if (failoverBlacklist.containsKey(targetHash)) {
+                        // Determine if this host is allowed to be a retry candidate
+                        if (failoverBlacklist.containsKey(targetHash)) {
 
-							// Find out when the particular key was blacklisted
-							Instant blacklistedWhen = failoverBlacklist.get(targetHash);
+                            // Find out when the particular key was blacklisted
+                            Instant blacklistedWhen = failoverBlacklist.get(targetHash);
 
-							// If the duration to blacklist the host and port combination has elapsed,
-							// remove it from the set
-							if (Duration.between(blacklistedWhen, Instant.now())
-									.toMillis() >= failoverBlacklistTimeout) {
-								failoverBlacklist.remove(targetHash);
-							} else {
-								continue;
-							}
-						}
-						// Construct an intermediate http url object representing the new URL we wish to
-						// query
-						HttpUrl intermediate = HttpUrl.get(url);
+                            // If the duration to blacklist the host and port combination has elapsed,
+                            // remove it from the set
+                            if (Duration.between(blacklistedWhen, Instant.now())
+                                    .toMillis() >= failoverBlacklistTimeout) {
+                                failoverBlacklist.remove(targetHash);
+                            } else {
+                                continue;
+                            }
+                        }
+                        // Construct an intermediate http url object representing the new URL we wish to
+                        // query
+                        HttpUrl intermediate = HttpUrl.get(url);
 
-						// New target url
-						target = originalRequest.url().newBuilder().host(intermediate.host()).port(intermediate.port())
-								.build();
-						
-						// Attempt to return the new response
-						try {
-							return chain.proceed(originalRequest.newBuilder().url(target).build());
-						} catch (ConnectException | ConsulException ex) {
-							failoverBlacklist.put(targetHash, Instant.now());
-							continue;
-						}
-					}
+                        // New target url
+                        target = originalRequest.url().newBuilder().host(intermediate.host()).port(intermediate.port())
+                                .build();
+                        
+                        // Attempt to return the new response
+                        try {
+                            return chain.proceed(originalRequest.newBuilder().url(target).build());
+                        } catch (ConnectException | ConsulException ex) {
+                            failoverBlacklist.put(targetHash, Instant.now());
+                            continue;
+                        }
+                    }
 
-					// The only way to retry is to have a new URL
-					if (target == null)
-						throw new ConsulException("No suitable targets available");
+                    // The only way to retry is to have a new URL
+                    if (target == null)
+                        throw new ConsulException("No suitable targets available");
 
-				}
+                }
 
-				return originalResponse;
-			};
+                return originalResponse;
+            };
 
-			return this;
-		}
+            return this;
+        }
 
         /**
-         * Sets the URL from a string.
-         *
-         * @param url The Consul agent URL.
-         * @return The builder.
-         */
+        * Sets the URL from a string.
+        *
+        * @param url The Consul agent URL.
+        * @return The builder.
+        */
         public Builder withUrl(String url) {
             try {
                 this.url = new URL(url);
@@ -566,11 +566,11 @@ public class Consul {
         }
 
         /**
-         * Sets the {@link SSLContext} for the client.
-         *
-         * @param sslContext The SSL context for HTTPS agents.
-         * @return The builder.
-         */
+        * Sets the {@link SSLContext} for the client.
+        *
+        * @param sslContext The SSL context for HTTPS agents.
+        * @return The builder.
+        */
         public Builder withSslContext(SSLContext sslContext) {
             this.sslContext = sslContext;
 
@@ -578,11 +578,11 @@ public class Consul {
         }
 
         /**
-         * Sets the {@link X509TrustManager} for the client.
-         *
-         * @param trustManager The SSL trust manager for HTTPS agents.
-         * @return The builder.
-         */
+        * Sets the {@link X509TrustManager} for the client.
+        *
+        * @param trustManager The SSL trust manager for HTTPS agents.
+        * @return The builder.
+        */
         public Builder withTrustManager(X509TrustManager trustManager) {
             this.trustManager = trustManager;
 
@@ -590,11 +590,11 @@ public class Consul {
         }
 
         /**
-         * Sets the {@link HostnameVerifier} for the client.
-         *
-         * @param hostnameVerifier The hostname verifier to use.
-         * @return The builder.
-         */
+        * Sets the {@link HostnameVerifier} for the client.
+        *
+        * @param hostnameVerifier The hostname verifier to use.
+        * @return The builder.
+        */
         public Builder withHostnameVerifier(HostnameVerifier hostnameVerifier) {
             this.hostnameVerifier = hostnameVerifier;
 
@@ -602,11 +602,11 @@ public class Consul {
         }
 
         /**
-         * Sets the {@link Proxy} for the client.
-         *
-         * @param proxy The proxy to use.
-         * @return The builder
-         */
+        * Sets the {@link Proxy} for the client.
+        *
+        * @param proxy The proxy to use.
+        * @return The builder
+        */
         public Builder withProxy(Proxy proxy) {
             this.proxy = proxy;
 
@@ -614,10 +614,10 @@ public class Consul {
         }
 
         /**
-         * Connect timeout for OkHttpClient
-         * @param timeoutMillis timeout values in milliseconds
-         * @return The builder
-         */
+        * Connect timeout for OkHttpClient
+        * @param timeoutMillis timeout values in milliseconds
+        * @return The builder
+        */
         public Builder withConnectTimeoutMillis(long timeoutMillis) {
             Preconditions.checkArgument(timeoutMillis >= 0, "Negative value");
             this.connectTimeoutMillis = timeoutMillis;
@@ -626,10 +626,10 @@ public class Consul {
         }
 
         /**
-         * Read timeout for OkHttpClient
-         * @param timeoutMillis timeout value in milliseconds
-         * @return The builder
-         */
+        * Read timeout for OkHttpClient
+        * @param timeoutMillis timeout value in milliseconds
+        * @return The builder
+        */
         public Builder withReadTimeoutMillis(long timeoutMillis) {
             Preconditions.checkArgument(timeoutMillis >= 0, "Negative value");
             this.readTimeoutMillis = timeoutMillis;
@@ -638,10 +638,10 @@ public class Consul {
         }
 
         /**
-         * Write timeout for OkHttpClient
-         * @param timeoutMillis timeout value in milliseconds
-         * @return The builder
-         */
+        * Write timeout for OkHttpClient
+        * @param timeoutMillis timeout value in milliseconds
+        * @return The builder
+        */
         public Builder withWriteTimeoutMillis(long timeoutMillis) {
             Preconditions.checkArgument(timeoutMillis >= 0, "Negative value");
             this.writeTimeoutMillis = timeoutMillis;
@@ -650,18 +650,18 @@ public class Consul {
         }
 
         /**
-         * Sets the ExecutorService to be used by the internal tasks dispatcher.
-         *
-         * By default, an ExecutorService is created internally.
-         * In this case, it will not be customizable nor manageable by the user application.
-         * It can only be shutdown by the {@link Consul#destroy()} method.
-         *
-         * When an application needs to be able to customize the ExecutorService parameters, and/or manage its lifecycle,
-         * it can provide an instance of ExecutorService to the Builder. In that case, this ExecutorService will be used instead of creating one internally.
-         *
-         * @param executorService The ExecutorService to be injected in the internal tasks dispatcher.
-         * @return
-         */
+        * Sets the ExecutorService to be used by the internal tasks dispatcher.
+        *
+        * By default, an ExecutorService is created internally.
+        * In this case, it will not be customizable nor manageable by the user application.
+        * It can only be shutdown by the {@link Consul#destroy()} method.
+        *
+        * When an application needs to be able to customize the ExecutorService parameters, and/or manage its lifecycle,
+        * it can provide an instance of ExecutorService to the Builder. In that case, this ExecutorService will be used instead of creating one internally.
+        *
+        * @param executorService The ExecutorService to be injected in the internal tasks dispatcher.
+        * @return
+        */
         public Builder withExecutorService(ExecutorService executorService) {
             this.executorService = executorService;
 
@@ -669,12 +669,12 @@ public class Consul {
         }
 
         /**
-         * Sets the configuration for the clients.
-         * The configuration will fallback on the library default configuration if elements are not set.
-         *
-         * @param clientConfig the configuration to use.
-         * @return The Builder
-         */
+        * Sets the configuration for the clients.
+        * The configuration will fallback on the library default configuration if elements are not set.
+        *
+        * @param clientConfig the configuration to use.
+        * @return The Builder
+        */
         public Builder withClientConfiguration(ClientConfig clientConfig) {
             this.clientConfig = clientConfig;
 
@@ -682,12 +682,12 @@ public class Consul {
         }
 
         /**
-         * Sets the event callback for the clients.
-         * The callback will be called by the consul client after each event.
-         *
-         * @param callback the callback to call.
-         * @return The Builder
-         */
+        * Sets the event callback for the clients.
+        * The callback will be called by the consul client after each event.
+        *
+        * @param callback the callback to call.
+        * @return The Builder
+        */
         public Builder withClientEventCallback(ClientEventCallback callback) {
             this.clientEventCallback = callback;
 
@@ -695,10 +695,10 @@ public class Consul {
         }
 
         /**
-         * Constructs a new {@link Consul} client.
-         *
-         * @return A new Consul client.
-         */
+        * Constructs a new {@link Consul} client.
+        *
+        * @return A new Consul client.
+        */
         public Consul build() {
             final Retrofit retrofit;
 
@@ -706,9 +706,9 @@ public class Consul {
             ExecutorService executorService = this.executorService;
             if (executorService == null) {
                 /**
-                 * mimics okhttp3.Dispatcher#executorService implementation, except
-                 * using daemon thread so shutdown is not blocked (issue #133)
-                 */
+                * mimics okhttp3.Dispatcher#executorService implementation, except
+                * using daemon thread so shutdown is not blocked (issue #133)
+                */
                 executorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60, TimeUnit.SECONDS,
                         new SynchronousQueue<>(), Util.threadFactory("OkHttp Dispatcher", true));
             }
@@ -783,9 +783,9 @@ public class Consul {
                 builder.addInterceptor(consulBookendInterceptor);
             }
             
-			if (consulFailoverInterceptor != null) {
-				builder.addInterceptor(consulFailoverInterceptor);
-			}
+            if (consulFailoverInterceptor != null) {
+                builder.addInterceptor(consulFailoverInterceptor);
+            }
 
             if (sslContext != null && trustManager != null) {
                 builder.sslSocketFactory(sslContext.getSocketFactory(), trustManager);

--- a/src/main/java/com/orbitz/consul/util/failover/ConsulFailoverInterceptor.java
+++ b/src/main/java/com/orbitz/consul/util/failover/ConsulFailoverInterceptor.java
@@ -54,7 +54,7 @@ public class ConsulFailoverInterceptor implements Interceptor {
 
 			// Get the next viable request
 			while ((nextRequest = strategy.computeNextStage(previousRequest, previousResponse)).isPresent()) {
-				System.out.println("Requesting with : " + nextRequest.get().url().uri().toString());
+
 				// Get the response from the last viable request
 				try {
 					final Response lastResponse = chain.proceed(nextRequest.get());

--- a/src/main/java/com/orbitz/consul/util/failover/ConsulFailoverInterceptor.java
+++ b/src/main/java/com/orbitz/consul/util/failover/ConsulFailoverInterceptor.java
@@ -1,0 +1,81 @@
+package com.orbitz.consul.util.failover;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Optional;
+
+import com.google.common.net.HostAndPort;
+import com.orbitz.consul.ConsulException;
+import com.orbitz.consul.util.failover.strategy.BlacklistingConsulFailoverStrategy;
+import com.orbitz.consul.util.failover.strategy.ConsulFailoverStrategy;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class ConsulFailoverInterceptor implements Interceptor {
+
+	// The consul failover strategy
+	private ConsulFailoverStrategy strategy;
+
+	/**
+	 * Default constructor for a set of hosts and ports
+	 * 
+	 * @param targets
+	 */
+	public ConsulFailoverInterceptor(Collection<HostAndPort> targets, long timeout) {
+		this(new BlacklistingConsulFailoverStrategy(targets, timeout));
+	}
+
+	/**
+	 * Allows customization of the interceptor chain
+	 * 
+	 * @param strategy
+	 */
+	public ConsulFailoverInterceptor(ConsulFailoverStrategy strategy) {
+		this.strategy = strategy;
+	}
+
+	@Override
+	public Response intercept(Chain chain) throws IOException {
+
+		// The original request
+		Request originalRequest = chain.request();
+
+		// If it is possible to do a failover on the first request (as in, one or more
+		// targets are viable)
+		if (strategy.isRequestViable(originalRequest)) {
+
+			// Initially, we have an inflight request and no response
+			Request previousRequest = originalRequest;
+			Response previousResponse = null;
+
+			Optional<Request> nextRequest;
+
+			// Get the next viable request
+			while ((nextRequest = strategy.computeNextStage(previousRequest, previousResponse)).isPresent()) {
+				System.out.println("Requesting with : " + nextRequest.get().url().uri().toString());
+				// Get the response from the last viable request
+				try {
+					final Response lastResponse = chain.proceed(nextRequest.get());
+
+					// If we were successful
+					if (lastResponse.isSuccessful())
+						return lastResponse;
+					else {
+						previousResponse = lastResponse;
+						previousRequest = nextRequest.get();
+					}
+				} catch (Exception ex) {
+					strategy.markRequestFailed(nextRequest.get());
+				}
+			}
+			throw new ConsulException("Unable to successfully determine a viable host for communication.");
+
+		} else {
+			throw new ConsulException(
+					"Consul failover strategy has determined that there are no viable hosts remaining.");
+		}
+
+	}
+}

--- a/src/main/java/com/orbitz/consul/util/failover/strategy/BlacklistingConsulFailoverStrategy.java
+++ b/src/main/java/com/orbitz/consul/util/failover/strategy/BlacklistingConsulFailoverStrategy.java
@@ -1,0 +1,118 @@
+package com.orbitz.consul.util.failover.strategy;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import com.google.common.net.HostAndPort;
+
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * @author Troy Heanssgen
+ *
+ */
+public class BlacklistingConsulFailoverStrategy implements ConsulFailoverStrategy {
+
+	// The map of blacklisted addresses
+	private Map<HostAndPort, Instant> blacklist = new HashMap<>();
+
+	// The map of viable targets
+	private Collection<HostAndPort> targets;
+
+	// The blacklist timeout
+	private long timeout;
+
+	/**
+	 * Constructs a blacklisting strategy with a collection of hosts and ports
+	 * 
+	 * @param targets A set of viable hosts
+	 */
+	public BlacklistingConsulFailoverStrategy(Collection<HostAndPort> targets, long timeout) {
+		this.targets = targets;
+		this.timeout = timeout;
+	}
+
+	@Override
+	public Optional<Request> computeNextStage(Request previousRequest, Response previousResponse) {
+
+		// Create a host and port
+		final HostAndPort initialTarget = fromRequest(previousRequest);
+
+		// If the previous response failed, disallow this request from going through
+		if (previousResponse != null && !previousResponse.isSuccessful()) {
+			this.blacklist.put(initialTarget, Instant.now());
+		}
+
+		// If our blacklist contains the target we care about
+		if (blacklist.containsKey(initialTarget)) {
+
+			// Find the first entity that doesnt exist in the blacklist
+			HostAndPort next = targets.stream().filter(target -> {
+
+				// If we have blacklisted this key
+				if (blacklist.containsKey(target)) {
+
+					// Get when we blacklisted this key
+					final Instant blacklistWhen = blacklist.get(target);
+
+					// If !(Duration(then, now) - timeout >=0) means that we remove this blacklist
+					// entry when the duration between
+					// the blacklist marker and now is greater than the timeout duration
+					if (!Duration.between(blacklistWhen, Instant.now()).minusMillis(timeout).isNegative()) {
+						blacklist.remove(target);
+						return true;
+					} else {
+						return false;
+					}
+				} else {
+					return true;
+				}
+			}).findAny().get();
+
+			// Construct the next URL using the old parameters (ensures we don't have to do
+			// a copy-on-write
+			final HttpUrl nextURL = previousRequest.url().newBuilder().host(next.getHost()).port(next.getPort())
+					.build();
+
+			// Return the result
+			return Optional.ofNullable(previousRequest.newBuilder().url(nextURL).build());
+		} else {
+
+			// Construct the next URL using the old parameters (ensures we don't have to do
+			// a copy-on-write
+			final HttpUrl nextURL = previousRequest.url().newBuilder().host(initialTarget.getHost())
+					.port(initialTarget.getPort()).build();
+
+			// Return the result
+			return Optional.ofNullable(previousRequest.newBuilder().url(nextURL).build());
+		}
+
+	}
+
+	@Override
+	public boolean isRequestViable(Request current) {
+		return targets.size() > blacklist.size() || !blacklist.containsKey(fromRequest(current));
+	}
+
+	/**
+	 * Reconstructs a HostAndPort instance from the request object
+	 * 
+	 * @param request
+	 * @return
+	 */
+	private HostAndPort fromRequest(Request request) {
+		return HostAndPort.fromParts(request.url().host(), request.url().port());
+	}
+
+	@Override
+	public void markRequestFailed(Request current) {
+		this.blacklist.put(fromRequest(current), Instant.now());	
+	}
+
+}

--- a/src/main/java/com/orbitz/consul/util/failover/strategy/ConsulFailoverStrategy.java
+++ b/src/main/java/com/orbitz/consul/util/failover/strategy/ConsulFailoverStrategy.java
@@ -1,0 +1,41 @@
+package com.orbitz.consul.util.failover.strategy;
+
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import okhttp3.Request;
+import okhttp3.Response;
+
+public interface ConsulFailoverStrategy {
+
+	
+	/**
+	 * Computes the next failover stage for the consul failover strategy. This allows the end user to customize the way
+	 * and methods by which additional failover targets may be selected.
+	 * @param previousRequest The last request to go out the door.
+	 * @param previousResponse The response that returned when previousRequest was completed. 
+	 * @return An optional failover request. This may return an empty optional, signaling that the request should be aborted
+	 */
+	@Nullable
+	public Optional<Request> computeNextStage(@Nonnull Request previousRequest, @Nullable Response previousResponse);
+	
+	/**
+	 * Determines if there is a viable candidate for the next request. This lets us short circuit the first attempted request
+	 * (such as when we know with certainty that a host should not be available) without interfering with the consul client too
+	 * much.
+	 * @param current The current inflight request.
+	 * @return A boolean representing if there is another possible request candidate available.
+	 */
+	public boolean isRequestViable(@Nonnull Request current);
+	
+	/**
+	 * Marks the specified request as a failed URL (in case of exceptions and other events that could cause
+	 * us to never get a response. This avoids infinite loops where the strategy can never be made aware that the request
+	 * has failed.
+	 * @param current The current request object representing a request that failed
+	 */
+	public void markRequestFailed(@Nonnull Request current);
+	
+}


### PR DESCRIPTION
First of all I apologize for the formatting of the code. I could not find any documentation regarding how this project prefers it's formatting, however if this is an issue I can reformat using the appropriate tool and reupload.

This change intends to add rudimentary support for multiple consul host failover. It accomplishes this by inserting an okhttp3 interceptor into the request chain and resubmitting the request as many times as needed in order to successfully contact a host.

We tried to change as little as possible, so all default functionality still exists verbatim. If a user configures the builder using `withMultipleHostAndPort(Collection<HostAndPort> hosts, int timeout)`, the first `HostAndPort` in the collection will become the primary URL (always requested, as per previous functionality) while the remaining addresses will be used in a fallback manner.

If a fallback address is not reachable, it will be blacklisted for `(timeout)` milliseconds before being retried as a potential candidate. It is possible that more complicated logic could be inserted (perhaps a RetryStrategy) to dynamically determine when/what host should be used as a fallback, however this change implements a round-robin style weighting.