### PR TITLE
Listener exceptions no longer impact other listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Integrations Tests rely on the assumption that a Consul server is running on loc
 
 You can run a Consul server in docker using the following command line:
 ```
-docker kill dev-consul ; docker rm dev-consul ; docker run -d -p 127.0.0.1:8500:8500 --name=dev-consul consul
+docker kill dev-consul ; docker rm dev-consul ; docker run -d -p 127.0.0.1:8500:8500 --name=dev-consul consul agent -dev -client 0.0.0.0 --enable-script-checks=true
 ```
 
 ### Eclipse-specific notes

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,12 @@
             <version>${commonscodec.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>retrofit-mock</artifactId>
+            <version>${retrofit.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/src/main/java/com/orbitz/consul/KeyValueClient.java
+++ b/src/main/java/com/orbitz/consul/KeyValueClient.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.nio.charset.Charset;
 import java.util.Optional;
+
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.UnsignedLongs;
 import com.orbitz.consul.async.ConsulResponseCallback;
@@ -61,6 +63,11 @@ public class KeyValueClient extends BaseClient {
     KeyValueClient(Retrofit retrofit, ClientConfig config, ClientEventCallback eventCallback) {
         super(CLIENT_NAME, config, eventCallback);
         this.api = retrofit.create(Api.class);
+    }
+
+    KeyValueClient(Api api, ClientConfig config, ClientEventCallback eventCallback) {
+        super(CLIENT_NAME, config, eventCallback);
+        this.api = api;
     }
 
     /**
@@ -633,7 +640,8 @@ public class KeyValueClient extends BaseClient {
     /**
      * Retrofit API interface.
      */
-    interface Api {
+    @VisibleForTesting
+    public interface Api {
 
         @GET("kv/{key}")
         Call<List<Value>> getValue(@Path("key") String key,

--- a/src/test/java/com/orbitz/consul/KeyValueClientFactory.java
+++ b/src/test/java/com/orbitz/consul/KeyValueClientFactory.java
@@ -1,0 +1,16 @@
+package com.orbitz.consul;
+
+import com.orbitz.consul.config.ClientConfig;
+import com.orbitz.consul.monitoring.ClientEventCallback;
+
+/**
+ * Allows tests to create KeyValueClient objects.
+ */
+public class KeyValueClientFactory {
+    private KeyValueClientFactory() {
+    }
+
+    public static KeyValueClient create(KeyValueClient.Api api, ClientConfig config, ClientEventCallback eventCallback) {
+        return new KeyValueClient(api, config, eventCallback);
+    }
+}

--- a/src/test/java/com/orbitz/consul/MockApiService.java
+++ b/src/test/java/com/orbitz/consul/MockApiService.java
@@ -1,0 +1,57 @@
+package com.orbitz.consul;
+
+import com.orbitz.consul.model.kv.TxResponse;
+import com.orbitz.consul.model.kv.Value;
+import okhttp3.Headers;
+import okhttp3.RequestBody;
+import retrofit2.Call;
+import retrofit2.Response;
+import retrofit2.mock.BehaviorDelegate;
+import retrofit2.mock.Calls;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ */
+public class MockApiService implements KeyValueClient.Api {
+    private final BehaviorDelegate<KeyValueClient.Api> delegate;
+
+    public MockApiService(BehaviorDelegate<KeyValueClient.Api> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Call<List<Value>> getValue(String key, Map<String, Object> query) {
+        final Headers headers = Headers.of("X-Consul-Knownleader", "true");
+        final Call<List<Object>> call = Calls.response(Response.success(Collections.emptyList(), headers));
+        return delegate.returning(call).getValue(key, query);
+    }
+
+    @Override
+    public Call<List<String>> getKeys(String key, Map<String, Object> query) {
+        return delegate.returningResponse(Collections.emptyList()).getKeys(key, query);
+    }
+
+    @Override
+    public Call<Boolean> putValue(String key, Map<String, Object> query) {
+        return delegate.returningResponse(true).putValue(key, query);
+    }
+
+    @Override
+    public Call<Boolean> putValue(String key, RequestBody data, Map<String, Object> query) {
+        return delegate.returningResponse(true).putValue(key, query);
+    }
+
+    @Override
+    public Call<Void> deleteValues(String key, Map<String, Object> query) {
+        return delegate.returningResponse(null).deleteValues(key, query);
+    }
+
+    @Override
+    public Call<TxResponse> performTransaction(RequestBody body, Map<String, Object> query) {
+        return delegate.returningResponse(null).performTransaction(body, query);
+    }
+}

--- a/src/test/java/com/orbitz/consul/cache/AlwaysThrowsListener.java
+++ b/src/test/java/com/orbitz/consul/cache/AlwaysThrowsListener.java
@@ -1,0 +1,15 @@
+package com.orbitz.consul.cache;
+
+import com.orbitz.consul.model.kv.Value;
+
+import java.util.Map;
+
+/**
+ *
+ */
+final class AlwaysThrowsListener implements ConsulCache.Listener<String, Value> {
+    @Override
+    public void notify(Map<String, Value> newValues) {
+        throw new RuntimeException("This listener always throws an exception!");
+    }
+}

--- a/src/test/java/com/orbitz/consul/cache/AsyncCallbackConsumer.java
+++ b/src/test/java/com/orbitz/consul/cache/AsyncCallbackConsumer.java
@@ -1,0 +1,50 @@
+package com.orbitz.consul.cache;
+
+import com.orbitz.consul.async.ConsulResponseCallback;
+import com.orbitz.consul.model.ConsulResponse;
+import com.orbitz.consul.model.kv.Value;
+
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ *
+ */
+public class AsyncCallbackConsumer implements ConsulCache.CallbackConsumer<Value>, AutoCloseable {
+    private final List<Value> result;
+    private int callCount;
+    private Thread thread;
+
+    public AsyncCallbackConsumer(List<Value> result) {
+        this.result = Collections.unmodifiableList(result);
+    }
+
+    @Override
+    public void consume(BigInteger index, final ConsulResponseCallback<List<Value>> callback) {
+        callCount++;
+        thread = new Thread(() -> {
+            callback.onComplete(new ConsulResponse<List<Value>>(result, 0, true, BigInteger.ZERO));
+        });
+        thread.setName("asyncCallbackConsumer");
+
+        thread.start();
+    }
+
+    public int getCallCount() {
+        return callCount;
+    }
+
+    @Override
+    public void close() {
+        try {
+            thread.join(1000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Thread did not terminate within timeout!");
+        }
+        if (thread.isAlive()) {
+            thread.interrupt();
+            throw new RuntimeException("Thread did not terminate in a timely manner!");
+        }
+    }
+}

--- a/src/test/java/com/orbitz/consul/cache/KVCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/KVCacheTest.java
@@ -1,15 +1,30 @@
 package com.orbitz.consul.cache;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.orbitz.consul.KeyValueClient;
+import com.orbitz.consul.KeyValueClientFactory;
+import com.orbitz.consul.MockApiService;
+import com.orbitz.consul.config.CacheConfig;
+import com.orbitz.consul.config.ClientConfig;
 import com.orbitz.consul.model.kv.ImmutableValue;
 import com.orbitz.consul.model.kv.Value;
+import com.orbitz.consul.monitoring.ClientEventCallback;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
+import org.apache.commons.lang3.time.StopWatch;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import retrofit2.Retrofit;
+import retrofit2.mock.BehaviorDelegate;
+import retrofit2.mock.MockRetrofit;
+import retrofit2.mock.NetworkBehavior;
 
+import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 @RunWith(JUnitParamsRunner.class)
@@ -51,5 +66,55 @@ public class KVCacheTest {
                 .key(key)
                 .value(Optional.empty())
                 .build();
+    }
+
+    @Test
+    public void testListenerWithMockRetrofit() throws InterruptedException {
+        final Retrofit retrofit = new Retrofit.Builder()
+                // For safety, this is a black hole IP: see RFC 6666
+                .baseUrl("http://[100:0:0:0:0:0:0:0]/")
+                .build();
+        final NetworkBehavior networkBehavior = NetworkBehavior.create();
+        networkBehavior.setDelay(0, TimeUnit.MILLISECONDS);
+        networkBehavior.setErrorPercent(0);
+        networkBehavior.setFailurePercent(0);
+        final MockRetrofit mockRetrofit = new MockRetrofit.Builder(retrofit)
+                .networkBehavior(networkBehavior)
+                .backgroundExecutor(Executors.newFixedThreadPool(1,
+                        new ThreadFactoryBuilder()
+                                .setNameFormat("mockRetrofitBackground-%d")
+                                .build()))
+                .build();
+
+        final BehaviorDelegate<KeyValueClient.Api> delegate = mockRetrofit.create(KeyValueClient.Api.class);
+        final MockApiService mockApiService = new MockApiService(delegate);
+
+
+        final CacheConfig cacheConfig = CacheConfig.builder()
+                .withMinDelayBetweenRequests(Duration.ofSeconds(10))
+                .build();
+
+        final KeyValueClient kvClient = KeyValueClientFactory.create(mockApiService, new ClientConfig(cacheConfig),
+                new ClientEventCallback() {
+        });
+
+
+        try (final KVCache kvCache = KVCache.newCache(kvClient, "")) {
+            kvCache.addListener(new AlwaysThrowsListener());
+            final StubListener goodListener = new StubListener();
+            kvCache.addListener(goodListener);
+
+            kvCache.start();
+
+            final StopWatch stopWatch = new StopWatch();
+
+            // Make sure that we wait some duration of time for asynchronous things to occur
+            while (stopWatch.getTime() < 5000 && goodListener.getCallCount() < 1) {
+                Thread.sleep(50);
+            }
+
+            Assert.assertEquals(1, goodListener.getCallCount());
+        }
+
     }
 }

--- a/src/test/java/com/orbitz/consul/cache/StubCallbackConsumer.java
+++ b/src/test/java/com/orbitz/consul/cache/StubCallbackConsumer.java
@@ -1,0 +1,32 @@
+package com.orbitz.consul.cache;
+
+import com.orbitz.consul.async.ConsulResponseCallback;
+import com.orbitz.consul.model.ConsulResponse;
+import com.orbitz.consul.model.kv.Value;
+
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ *
+ */
+public class StubCallbackConsumer implements ConsulCache.CallbackConsumer<Value> {
+
+    private final List<Value> result;
+    private int callCount;
+
+    public StubCallbackConsumer(List<Value> result) {
+        this.result = Collections.unmodifiableList(result);
+    }
+
+    @Override
+    public void consume(BigInteger index, ConsulResponseCallback<List<Value>> callback) {
+        callCount++;
+        callback.onComplete(new ConsulResponse<>(result, 0, true, BigInteger.ZERO));
+    }
+
+    public int getCallCount() {
+        return callCount;
+    }
+}

--- a/src/test/java/com/orbitz/consul/cache/StubListener.java
+++ b/src/test/java/com/orbitz/consul/cache/StubListener.java
@@ -1,0 +1,28 @@
+package com.orbitz.consul.cache;
+
+import com.orbitz.consul.model.kv.Value;
+
+import java.util.Map;
+
+/**
+ *
+ */
+final class StubListener implements ConsulCache.Listener<String, Value> {
+    private int callCount = 0;
+    private Map<String, Value> lastValues;
+
+
+    @Override
+    public void notify(Map<String, Value> newValues) {
+        callCount++;
+        lastValues = newValues;
+    }
+
+    public int getCallCount() {
+        return callCount;
+    }
+
+    public Map<String, Value> getLastValues() {
+        return lastValues;
+    }
+}


### PR DESCRIPTION
- Exceptions thrown by listeners are now caught so that the remaining
listeners will still be called. Such exceptions are logged at 
WARN level.
- runCallback() must execute in the executorService thread, otherwise
if the delay is set to zero, StackOverflow can occur.
- Added fail-fast null checks for ConsulCache constructor params.
Previously, NPE would have been thrown later on.
- Added name format for ConsulCache's scheduled executor, to
differentiate that thread from others in stack dumps, logs, etc.
- Fixed StackOverflowException when using a CallbackConsumer which
does not do its work in a separate thread, and when the minimum duration
between requests config value is set to zero.
- Added param to docker command in README to match travis config, so
that integration tests work when running locally.