### PR TITLE
Bugfix into `BlacklistingConsulFailoverStrategy` 

### DIFF
--- a/src/main/java/com/orbitz/consul/util/failover/strategy/BlacklistingConsulFailoverStrategy.java
+++ b/src/main/java/com/orbitz/consul/util/failover/strategy/BlacklistingConsulFailoverStrategy.java
@@ -46,7 +46,7 @@ public class BlacklistingConsulFailoverStrategy implements ConsulFailoverStrateg
 		if (blacklist.containsKey(initialTarget)) {
 
 			// Find the first entity that doesnt exist in the blacklist
-			HostAndPort next = targets.stream().filter(target -> {
+			Optional<HostAndPort> optionalNext = targets.stream().filter(target -> {
 
 				// If we have blacklisted this key
 				if (blacklist.containsKey(target)) {
@@ -64,7 +64,12 @@ public class BlacklistingConsulFailoverStrategy implements ConsulFailoverStrateg
 						return false;
 				} else
 					return true;
-			}).findAny().get();
+			}).findAny();
+
+			if (!optionalNext.isPresent()) {
+				return Optional.empty();
+			}
+			HostAndPort next = optionalNext.get();
 
 			// Construct the next URL using the old parameters (ensures we don't have to do
 			// a copy-on-write

--- a/src/test/java/com/orbitz/consul/util/failover/strategy/BlacklistingConsulFailoverStrategyTest.java
+++ b/src/test/java/com/orbitz/consul/util/failover/strategy/BlacklistingConsulFailoverStrategyTest.java
@@ -1,0 +1,79 @@
+package com.orbitz.consul.util.failover.strategy;
+
+import com.google.common.net.HostAndPort;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class BlacklistingConsulFailoverStrategyTest {
+    private BlacklistingConsulFailoverStrategy blacklistingConsulFailoverStrategy;
+
+    @Before
+    public void setup() {
+        // Create a set of targets
+        final Collection<HostAndPort> targets = new ArrayList<>();
+        targets.add(HostAndPort.fromParts("1.2.3.4", 8501));
+        targets.add(HostAndPort.fromParts("localhost", 8501));
+
+        blacklistingConsulFailoverStrategy = new BlacklistingConsulFailoverStrategy(targets, 100000);
+    }
+
+    @Test
+    public void getFirstUrlBack() {
+        Request previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
+        Response previousResponse = null;
+
+        Optional<Request> result = blacklistingConsulFailoverStrategy.computeNextStage(previousRequest, previousResponse);
+
+        assertEquals(true, result.isPresent());
+        assertEquals("https://1.2.3.4:8501/v1/agent/members", result.get().url().toString());
+    }
+
+    @Test
+    public void getSecondUrlBackAfterFirstOneIsBlacklisted() {
+        Request previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
+        Response previousResponse = null;
+
+        Optional<Request> result1 = blacklistingConsulFailoverStrategy.computeNextStage(previousRequest, previousResponse);
+
+        assertEquals(true, result1.isPresent());
+        assertEquals("https://1.2.3.4:8501/v1/agent/members", result1.get().url().toString());
+
+        blacklistingConsulFailoverStrategy.markRequestFailed(result1.get());
+        Optional<Request> result2 = blacklistingConsulFailoverStrategy.computeNextStage(result1.get(), previousResponse);
+
+        assertEquals(true, result2.isPresent());
+        assertEquals("https://localhost:8501/v1/agent/members", result2.get().url().toString());
+    }
+
+    @Test
+    public void getNoUrlBackAfterBothAreBlacklisted() {
+        Request previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
+        Response previousResponse = null;
+
+        Optional<Request> result1 = blacklistingConsulFailoverStrategy.computeNextStage(previousRequest, previousResponse);
+
+        assertEquals(true, result1.isPresent());
+        assertEquals("https://1.2.3.4:8501/v1/agent/members", result1.get().url().toString());
+
+        blacklistingConsulFailoverStrategy.markRequestFailed(result1.get());
+        Optional<Request> result2 = blacklistingConsulFailoverStrategy.computeNextStage(result1.get(), previousResponse);
+
+        assertEquals(true, result2.isPresent());
+        assertEquals("https://localhost:8501/v1/agent/members", result2.get().url().toString());
+
+        blacklistingConsulFailoverStrategy.markRequestFailed(result2.get());
+
+        Optional<Request> result3 = blacklistingConsulFailoverStrategy.computeNextStage(result2.get(), previousResponse);
+
+        assertEquals(false, result3.isPresent());
+    }
+}


### PR DESCRIPTION
so that it can return an empty Optional value when all consul hosts have been blacklisted.  
Previously it would throw a `NoSuchElementException` instead of returning an empty value.  This allows for the `ConsulFailoverInterceptor` to correctly throw a `ConsulException` in these cases.