### PR TITLE
Support for https only environments

### DIFF
--- a/src/main/java/com/orbitz/consul/Consul.java
+++ b/src/main/java/com/orbitz/consul/Consul.java
@@ -3,9 +3,6 @@ package com.orbitz.consul;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -267,6 +264,7 @@ public class Consul {
     * Builder for {@link Consul} client objects.
     */
     public static class Builder {
+        private String scheme = "http";
         private URL url;
         private SSLContext sslContext;
         private X509TrustManager trustManager;
@@ -288,7 +286,7 @@ public class Consul {
 
         {
             try {
-                url = new URL("http", DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT, "");
+                url = new URL(scheme, DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT, "");
             } catch (MalformedURLException e) {
                 throw new RuntimeException(e);
             }
@@ -310,6 +308,31 @@ public class Consul {
         public Builder withUrl(URL url) {
             this.url = url;
 
+            return this;
+        }
+
+        /**
+         * Use HTTPS connections for all requests.
+         *
+         * @param withHttps Set to true to use https for all Consul requests.
+         * @return The builder.
+         */
+        public Builder withHttps(boolean withHttps){
+            if (withHttps) {
+                this.scheme = "https";
+            } else {
+                this.scheme = "http";
+            }
+
+            //if url was already generated from a call to withMultipleHostAndPort or withMultipleHostAndPort
+            //it might have the old scheme saved into url, so recreate it here if it has changed
+            if (!this.url.getProtocol().equals(this.scheme)) {
+                try {
+                    this.url = new URL(scheme, this.url.getHost(), this.url.getPort(), "");
+                } catch (MalformedURLException e) {
+                    throw new RuntimeException(e);
+                }
+            }
             return this;
         }
 
@@ -440,7 +463,7 @@ public class Consul {
         */
         public Builder withHostAndPort(HostAndPort hostAndPort) {
             try {
-                this.url = new URL("http", hostAndPort.getHost(), hostAndPort.getPort(), "");
+                this.url = new URL(scheme, hostAndPort.getHost(), hostAndPort.getPort(), "");
             } catch (MalformedURLException e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/com/orbitz/consul/util/failover/ConsulFailoverInterceptor.java
+++ b/src/main/java/com/orbitz/consul/util/failover/ConsulFailoverInterceptor.java
@@ -8,8 +8,11 @@ import com.orbitz.consul.ConsulException;
 import com.orbitz.consul.util.failover.strategy.*;
 
 import okhttp3.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ConsulFailoverInterceptor implements Interceptor {
+	private final static Logger LOGGER = LoggerFactory.getLogger(ConsulFailoverInterceptor.class);
 
 	// The consul failover strategy
 	private ConsulFailoverStrategy strategy;
@@ -59,6 +62,7 @@ public class ConsulFailoverInterceptor implements Interceptor {
 					// This is because a 400 series error is a valid code (Permission Denied/Key Not Found)
 					return chain.proceed(next);
 				} catch (Exception ex) {
+					LOGGER.debug("Failed to connect to {}", nextRequest.get().url(), ex);
 					strategy.markRequestFailed(nextRequest.get());
 				}
 			throw new ConsulException("Unable to successfully determine a viable host for communication.");


### PR DESCRIPTION
Added the `withHttps` method to the Consul builder class that can set your url scheme to be "https".
Added a debug log message to `ConsulFailoverInterceptor` since it is the only place to find the full url and server where the failed request happened.

Without this what we saw when building a client like this:
```
List<HostAndPort> consulServers = new ArrayList<>();
consulServers.add(HostAndPort.fromParts("consul1.internal", 8501));
consulServers.add(HostAndPort.fromParts("consul2.internal", 8501));

Consul.Builder builder = Consul.builder()
        .withMultipleHostAndPort(consulServers, 30000);
```
resulted in the `url` field be use `http`, but in our environment we have http disabled and can only use https on port 8501.
