### PR TITLE
Added support for cached results consistency

### DIFF
--- a/src/main/java/com/orbitz/consul/CatalogClient.java
+++ b/src/main/java/com/orbitz/consul/CatalogClient.java
@@ -44,7 +44,16 @@ public class CatalogClient extends BaseClient {
      * @return A list of datacenter names.
      */
     public List<String> getDatacenters() {
-        return http.extract(api.getDatacenters());
+        return getDatacenters(QueryOptions.BLANK);
+    }
+
+    /**
+     * Get the list of datacenters with query options
+     * @param queryOptions
+     * @return
+     */
+    public List<String> getDatacenters(QueryOptions queryOptions) {
+        return http.extract(api.getDatacenters(queryOptions.toHeaders()));
     }
 
     /**
@@ -70,7 +79,8 @@ public class CatalogClient extends BaseClient {
      */
     public ConsulResponse<List<Node>> getNodes(QueryOptions queryOptions) {
         return http.extractConsulResponse(api.getNodes(queryOptions.toQuery(),
-                queryOptions.getTag(), queryOptions.getNodeMeta()));
+                queryOptions.getTag(), queryOptions.getNodeMeta(),
+                queryOptions.toHeaders()));
     }
 
     /**
@@ -84,7 +94,7 @@ public class CatalogClient extends BaseClient {
      */
     public void getNodes(QueryOptions queryOptions, ConsulResponseCallback<List<Node>> callback) {
         http.extractConsulResponse(api.getNodes(queryOptions.toQuery(), queryOptions.getTag(),
-                queryOptions.getNodeMeta()), callback);
+                queryOptions.getNodeMeta(), queryOptions.toHeaders()), callback);
     }
 
     /**
@@ -120,7 +130,7 @@ public class CatalogClient extends BaseClient {
      */
     public ConsulResponse<Map<String, List<String>>> getServices(QueryOptions queryOptions) {
         return http.extractConsulResponse(api.getServices(queryOptions.toQuery(),
-                queryOptions.getTag(), queryOptions.getNodeMeta()));
+                queryOptions.getTag(), queryOptions.getNodeMeta(), queryOptions.toHeaders()));
     }
 
     /**
@@ -134,7 +144,7 @@ public class CatalogClient extends BaseClient {
      */
     public void getServices(QueryOptions queryOptions, ConsulResponseCallback<Map<String, List<String>>> callback) {
         http.extractConsulResponse(api.getServices(queryOptions.toQuery(),
-                queryOptions.getTag(), queryOptions.getNodeMeta()), callback);
+                queryOptions.getTag(), queryOptions.getNodeMeta(), queryOptions.toHeaders()), callback);
     }
 
     /**
@@ -160,7 +170,7 @@ public class CatalogClient extends BaseClient {
      */
     public ConsulResponse<List<CatalogService>> getService(String service, QueryOptions queryOptions) {
         return http.extractConsulResponse(api.getService(service, queryOptions.toQuery(),
-                queryOptions.getTag(), queryOptions.getNodeMeta()));
+                queryOptions.getTag(), queryOptions.getNodeMeta(), queryOptions.toHeaders()));
     }
 
     /**
@@ -175,7 +185,7 @@ public class CatalogClient extends BaseClient {
      */
     public void getService(String service, QueryOptions queryOptions, ConsulResponseCallback<List<CatalogService>> callback) {
         http.extractConsulResponse(api.getService(service, queryOptions.toQuery(),
-                queryOptions.getTag(), queryOptions.getNodeMeta()), callback);
+                queryOptions.getTag(), queryOptions.getNodeMeta(), queryOptions.toHeaders()), callback);
     }
 
     /**
@@ -199,7 +209,7 @@ public class CatalogClient extends BaseClient {
      */
     public ConsulResponse<CatalogNode> getNode(String node, QueryOptions queryOptions) {
         return http.extractConsulResponse(api.getNode(node, queryOptions.toQuery(),
-                queryOptions.getTag(), queryOptions.getNodeMeta()));
+                queryOptions.getTag(), queryOptions.getNodeMeta(), queryOptions.toHeaders()));
     }
 
     /**
@@ -212,7 +222,7 @@ public class CatalogClient extends BaseClient {
      */
     public void getNode(String node, QueryOptions queryOptions, ConsulResponseCallback<CatalogNode> callback) {
         http.extractConsulResponse(api.getNode(node, queryOptions.toQuery(),
-                queryOptions.getTag(), queryOptions.getNodeMeta()), callback);
+                queryOptions.getTag(), queryOptions.getNodeMeta(), queryOptions.toHeaders()), callback);
     }
 
     /**
@@ -265,29 +275,33 @@ public class CatalogClient extends BaseClient {
     interface Api {
 
         @GET("catalog/datacenters")
-        Call<List<String>> getDatacenters();
+        Call<List<String>> getDatacenters(@HeaderMap Map<String, String> headers);
 
         @GET("catalog/nodes")
         Call<List<Node>> getNodes(@QueryMap Map<String, Object> query,
                                   @Query("tag") List<String> tag,
-                                  @Query("node-meta") List<String> nodeMeta);
+                                  @Query("node-meta") List<String> nodeMeta,
+                                  @HeaderMap Map<String, String> headers);
 
         @GET("catalog/node/{node}")
         Call<CatalogNode> getNode(@Path("node") String node,
                                   @QueryMap Map<String, Object> query,
                                   @Query("tag") List<String> tag,
-                                  @Query("node-meta") List<String> nodeMeta);
+                                  @Query("node-meta") List<String> nodeMeta,
+                                  @HeaderMap Map<String, String> headers);
 
         @GET("catalog/services")
         Call<Map<String, List<String>>> getServices(@QueryMap Map<String, Object> query,
                                                     @Query("tag") List<String> tag,
-                                                    @Query("node-meta") List<String> nodeMeta);
+                                                    @Query("node-meta") List<String> nodeMeta,
+                                                    @HeaderMap Map<String, String> headers);
 
         @GET("catalog/service/{service}")
         Call<List<CatalogService>> getService(@Path("service") String service,
                                               @QueryMap Map<String, Object> queryMeta,
                                               @Query("tag") List<String> tag,
-                                              @Query("node-meta") List<String> nodeMeta);
+                                              @Query("node-meta") List<String> nodeMeta,
+                                              @HeaderMap Map<String, String> headers);
 
         @PUT("catalog/register")
         Call<Void> register(@Body CatalogRegistration registration, @QueryMap Map<String, Object> options);

--- a/src/main/java/com/orbitz/consul/HealthClient.java
+++ b/src/main/java/com/orbitz/consul/HealthClient.java
@@ -12,6 +12,7 @@ import com.orbitz.consul.option.QueryOptions;
 import retrofit2.Call;
 import retrofit2.Retrofit;
 import retrofit2.http.GET;
+import retrofit2.http.HeaderMap;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 import retrofit2.http.QueryMap;
@@ -65,7 +66,7 @@ public class HealthClient extends BaseClient {
     public ConsulResponse<List<HealthCheck>> getNodeChecks(String node,
                                                            QueryOptions queryOptions) {
         return http.extractConsulResponse(api.getNodeChecks(node, queryOptions.toQuery(),
-                queryOptions.getTag(), queryOptions.getNodeMeta()));
+                queryOptions.getTag(), queryOptions.getNodeMeta(), queryOptions.toHeaders()));
     }
 
     /**
@@ -92,7 +93,7 @@ public class HealthClient extends BaseClient {
     public ConsulResponse<List<HealthCheck>> getServiceChecks(String service,
                                                               QueryOptions queryOptions) {
         return http.extractConsulResponse(api.getServiceChecks(service, queryOptions.toQuery(),
-                queryOptions.getTag(), queryOptions.getNodeMeta()));
+                queryOptions.getTag(), queryOptions.getNodeMeta(), queryOptions.toHeaders()));
     }
 
     /**
@@ -110,7 +111,7 @@ public class HealthClient extends BaseClient {
                                  QueryOptions queryOptions,
                                  ConsulResponseCallback<List<HealthCheck>> callback) {
         http.extractConsulResponse(api.getServiceChecks(service, queryOptions.toQuery(),
-                queryOptions.getTag(), queryOptions.getNodeMeta()), callback);
+                queryOptions.getTag(), queryOptions.getNodeMeta(), queryOptions.toHeaders()), callback);
     }
 
     /**
@@ -139,7 +140,7 @@ public class HealthClient extends BaseClient {
     public ConsulResponse<List<HealthCheck>> getChecksByState(State state,
                                                               QueryOptions queryOptions) {
         return http.extractConsulResponse(api.getChecksByState(state.getName(), queryOptions.toQuery(),
-                queryOptions.getTag(), queryOptions.getNodeMeta()));
+                queryOptions.getTag(), queryOptions.getNodeMeta(), queryOptions.toHeaders()));
     }
 
     /**
@@ -156,7 +157,7 @@ public class HealthClient extends BaseClient {
     public void getChecksByState(State state, QueryOptions queryOptions,
                                  ConsulResponseCallback<List<HealthCheck>> callback) {
         http.extractConsulResponse(api.getChecksByState(state.getName(), queryOptions.toQuery(),
-                queryOptions.getTag(), queryOptions.getNodeMeta()), callback);
+                queryOptions.getTag(), queryOptions.getNodeMeta(), queryOptions.toHeaders()), callback);
     }
 
     /**
@@ -187,7 +188,7 @@ public class HealthClient extends BaseClient {
                                                                           QueryOptions queryOptions) {
         return http.extractConsulResponse(api.getServiceInstances(service,
                 optionsFrom(ImmutableMap.of("passing", "true"), queryOptions.toQuery()),
-                queryOptions.getTag(), queryOptions.getNodeMeta()));
+                queryOptions.getTag(), queryOptions.getNodeMeta(), queryOptions.toHeaders()));
     }
 
 
@@ -207,7 +208,7 @@ public class HealthClient extends BaseClient {
                                            ConsulResponseCallback<List<ServiceHealth>> callback) {
         http.extractConsulResponse(api.getServiceInstances(service,
                 optionsFrom(ImmutableMap.of("passing", "true"), queryOptions.toQuery()),
-                queryOptions.getTag(), queryOptions.getNodeMeta()), callback);
+                queryOptions.getTag(), queryOptions.getNodeMeta(), queryOptions.toHeaders()), callback);
     }
 
     /**
@@ -236,7 +237,7 @@ public class HealthClient extends BaseClient {
      */
     public ConsulResponse<List<ServiceHealth>> getAllServiceInstances(String service, QueryOptions queryOptions) {
         return http.extractConsulResponse(api.getServiceInstances(service, queryOptions.toQuery(),
-                queryOptions.getTag(), queryOptions.getNodeMeta()));
+                queryOptions.getTag(), queryOptions.getNodeMeta(), queryOptions.toHeaders()));
     }
 
     /**
@@ -254,7 +255,7 @@ public class HealthClient extends BaseClient {
     public void getAllServiceInstances(String service, QueryOptions queryOptions,
                                        ConsulResponseCallback<List<ServiceHealth>> callback) {
         http.extractConsulResponse(api.getServiceInstances(service, queryOptions.toQuery(),
-                queryOptions.getTag(), queryOptions.getNodeMeta()), callback);
+                queryOptions.getTag(), queryOptions.getNodeMeta(), queryOptions.toHeaders()), callback);
     }
 
     private static Map<String, Object> optionsFrom(Map<String, ?>... options) {
@@ -276,24 +277,28 @@ public class HealthClient extends BaseClient {
         Call<List<HealthCheck>> getNodeChecks(@Path("node") String node,
                                               @QueryMap Map<String, Object> query,
                                               @Query("tag") List<String> tag,
-                                              @Query("node-meta") List<String> nodeMeta);
+                                              @Query("node-meta") List<String> nodeMeta,
+                                              @HeaderMap Map<String, String> headers);
 
         @GET("health/checks/{service}")
         Call<List<HealthCheck>> getServiceChecks(@Path("service") String service,
                                                  @QueryMap Map<String, Object> query,
                                                  @Query("tag") List<String> tag,
-                                                 @Query("node-meta") List<String> nodeMeta);
+                                                 @Query("node-meta") List<String> nodeMeta,
+                                                 @HeaderMap Map<String, String> headers);
 
         @GET("health/state/{state}")
         Call<List<HealthCheck>> getChecksByState(@Path("state") String state,
                                                  @QueryMap Map<String, Object> query,
                                                  @Query("tag") List<String> tag,
-                                                 @Query("node-meta") List<String> nodeMeta);
+                                                 @Query("node-meta") List<String> nodeMeta,
+                                                 @HeaderMap Map<String, String> headers);
 
         @GET("health/service/{service}")
         Call<List<ServiceHealth>> getServiceInstances(@Path("service") String service,
                                                       @QueryMap Map<String, Object> query,
                                                       @Query("tag") List<String> tag,
-                                                      @Query("node-meta") List<String> nodeMeta);
+                                                      @Query("node-meta") List<String> nodeMeta,
+                                                      @HeaderMap Map<String, String> headers);
     }
 }

--- a/src/main/java/com/orbitz/consul/KeyValueClient.java
+++ b/src/main/java/com/orbitz/consul/KeyValueClient.java
@@ -32,6 +32,7 @@ import retrofit2.Retrofit;
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
 import retrofit2.http.GET;
+import retrofit2.http.HeaderMap;
 import retrofit2.http.Headers;
 import retrofit2.http.PUT;
 import retrofit2.http.Path;
@@ -106,7 +107,9 @@ public class KeyValueClient extends BaseClient {
      */
     public Optional<Value> getValue(String key, QueryOptions queryOptions) {
         try {
-            return getSingleValue(http.extract(api.getValue(trimLeadingSlash(key), queryOptions.toQuery()), NOT_FOUND_404));
+            return getSingleValue(http.extract(api.getValue(trimLeadingSlash(key),
+                                               queryOptions.toQuery()),
+                                  NOT_FOUND_404));
         } catch (ConsulException ignored) {
             if(ignored.getCode() != NOT_FOUND_404) {
                 throw ignored;
@@ -134,7 +137,8 @@ public class KeyValueClient extends BaseClient {
             if (consulValue.isPresent()) {
                 ConsulResponse<Value> result =
                         new ConsulResponse<>(consulValue.get(), consulResponse.getLastContact(),
-                                                    consulResponse.isKnownLeader(), consulResponse.getIndex());
+                                                    consulResponse.isKnownLeader(), consulResponse.getIndex(),
+                                                    consulResponse.getCacheReponseInfo());
                 return Optional.of(result);
             }
         } catch (ConsulException ignored) {
@@ -163,7 +167,8 @@ public class KeyValueClient extends BaseClient {
                 callback.onComplete(
                         new ConsulResponse<>(getSingleValue(consulResponse.getResponse()),
                                 consulResponse.getLastContact(),
-                                consulResponse.isKnownLeader(), consulResponse.getIndex()));
+                                consulResponse.isKnownLeader(), consulResponse.getIndex(),
+                                consulResponse.getCacheReponseInfo()));
             }
 
             @Override

--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -51,6 +52,7 @@ public class ConsulCache<K, V> implements AutoCloseable {
     private final AtomicReference<BigInteger> latestIndex = new AtomicReference<>(null);
     private final AtomicLong lastContact = new AtomicLong();
     private final AtomicBoolean isKnownLeader = new AtomicBoolean();
+    private final AtomicReference<ConsulResponse.CacheResponseInfo> lastCacheInfo = new AtomicReference<>(null);
     private final AtomicReference<ImmutableMap<K, V>> lastResponse = new AtomicReference<>(null);
     private final AtomicReference<State> state = new AtomicReference<>(State.latent);
     private final CountDownLatch initLatch = new CountDownLatch(1);
@@ -248,7 +250,7 @@ public class ConsulCache<K, V> implements AutoCloseable {
     }
 
     public ConsulResponse<ImmutableMap<K,V>> getMapWithMetadata() {
-        return new ConsulResponse<>(lastResponse.get(), lastContact.get(), isKnownLeader.get(), latestIndex.get());
+        return new ConsulResponse<>(lastResponse.get(), lastContact.get(), isKnownLeader.get(), latestIndex.get(), Optional.ofNullable(lastCacheInfo.get()));
     }
 
     @VisibleForTesting

--- a/src/main/java/com/orbitz/consul/model/acl/BaseTokenResponse.java
+++ b/src/main/java/com/orbitz/consul/model/acl/BaseTokenResponse.java
@@ -1,16 +1,10 @@
 package com.orbitz.consul.model.acl;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.immutables.value.Value;
 
 import java.math.BigInteger;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
-
 
 public abstract class BaseTokenResponse {
 

--- a/src/main/java/com/orbitz/consul/model/agent/Config.java
+++ b/src/main/java/com/orbitz/consul/model/agent/Config.java
@@ -4,11 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.util.Optional;
-import com.google.common.collect.ImmutableList;
 import org.immutables.value.Value;
-
-import java.util.List;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableConfig.class)

--- a/src/main/java/com/orbitz/consul/model/agent/DebugConfig.java
+++ b/src/main/java/com/orbitz/consul/model/agent/DebugConfig.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Optional;
-import com.google.common.collect.ImmutableList;
 import org.immutables.value.Value;
 
 import java.util.List;

--- a/src/main/java/com/orbitz/consul/model/catalog/CatalogNode.java
+++ b/src/main/java/com/orbitz/consul/model/catalog/CatalogNode.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.orbitz.consul.model.agent.ImmutableRegistration;
 import com.orbitz.consul.model.health.Node;
 import com.orbitz.consul.model.health.Service;
 import org.immutables.value.Value;

--- a/src/main/java/com/orbitz/consul/model/catalog/CatalogService.java
+++ b/src/main/java/com/orbitz/consul/model/catalog/CatalogService.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Optional;
 
-import com.orbitz.consul.model.health.Service;
 import org.immutables.value.Value;
 
 import java.util.List;

--- a/src/main/java/com/orbitz/consul/option/ConsistencyMode.java
+++ b/src/main/java/com/orbitz/consul/option/ConsistencyMode.java
@@ -1,17 +1,104 @@
 package com.orbitz.consul.option;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
-public enum ConsistencyMode {
-    DEFAULT(null), STALE("stale"), CONSISTENT("consistent"), CACHED("cached");
+import com.google.common.collect.ImmutableMap;
 
-    private String param;
+public class ConsistencyMode {
+    public final static ConsistencyMode DEFAULT = new ConsistencyMode("DEFAULT", 0, null);
+    public final static ConsistencyMode STALE = new ConsistencyMode("STALE", 1, "stale");
+    public final static ConsistencyMode CONSISTENT = new ConsistencyMode("CONSISTENT", 2, "consistent");
 
-    ConsistencyMode(String param) {
-        this.param = param;
+    private final String name;
+    private final int ordinal;
+    private final String param;
+    private final Map<String, String> additionalHeaders;
+
+    private ConsistencyMode(final String name, int ordinal, final String param) {
+        this(name, ordinal, param, Collections.emptyMap());
     }
 
-    public Optional<String> toParam() {
+    private ConsistencyMode(final String name, int ordinal, final String param, final Map<String, String> headers) {
+        this.name = name;
+        this.ordinal = ordinal;
+        this.param = param;
+        this.additionalHeaders = headers;
+    }
+
+    public final Optional<String> toParam() {
         return Optional.ofNullable(param);
+    }
+
+    /**
+     * Get the Additional HTTP headers to add to request.
+     *
+     * @return a not null but possibly empty map
+     */
+    public final Map<String, String> getAdditionalHeaders() {
+        return additionalHeaders;
+    }
+
+    /**
+     * Creates a cached Consistency.
+     *
+     * @param maxAgeInSeconds   Optional duration in seconds after which data is
+     *                          considered too old
+     * @param maxStaleInSeconds Optional duration for which data can be late
+     *                          compared to Consul Server leader.
+     * @return a not null ConsistencyMode
+     * @see https://www.consul.io/api/features/caching.html#simple-caching
+     */
+    public final static ConsistencyMode createCachedConsistencyWithMaxAgeAndStale(final Optional<Long> maxAgeInSeconds,
+            final Optional<Long> maxStaleInSeconds) {
+        String maxAge = "";
+        if (maxAgeInSeconds.isPresent()) {
+            final long v = maxAgeInSeconds.get().longValue();
+            if (v < 0) {
+                throw new IllegalArgumentException("maxAgeInSeconds must greater or equal to 0");
+            }
+            maxAge += String.format("max-age=%d", v);
+        }
+
+        if (maxStaleInSeconds.isPresent()) {
+            final long v = maxStaleInSeconds.get().longValue();
+            if (v < 0){
+                throw new IllegalArgumentException("maxStaleInSeconds must greater or equal to 0");
+            }
+            if (!maxAge.isEmpty()){
+                maxAge += ",";
+            }
+            maxAge += String.format("stale-if-error=%d", v);
+        }
+        Map<String, String> headers;
+        if (maxAge.isEmpty()) {
+            headers = Collections.emptyMap();
+        } else {
+            headers = ImmutableMap.of("Cache-Control", maxAge);
+        }
+        return new ConsistencyMode("CACHED", 3, "cached", headers);
+    }
+
+    // The next methods are for compatibility with old enum type
+    /**
+     * ConsistencyMode used t be an enum, implement it.
+     * @return the old enum name
+     */
+    public final String name(){
+        return name;
+    }
+
+    public int ordinal(){
+        return ordinal;
+    }
+
+    public static final ConsistencyMode[] values(){
+        ConsistencyMode[] res = new ConsistencyMode[3];
+        res[0] = DEFAULT;
+        res[1] = STALE;
+        res[2] = CONSISTENT;
+        // Don't push CACHED as it is just to keep backward compatibility
+        return res;
     }
 }

--- a/src/main/java/com/orbitz/consul/option/ConsistencyMode.java
+++ b/src/main/java/com/orbitz/consul/option/ConsistencyMode.java
@@ -3,7 +3,7 @@ package com.orbitz.consul.option;
 import java.util.Optional;
 
 public enum ConsistencyMode {
-    DEFAULT(null), STALE("stale"), CONSISTENT("consistent");
+    DEFAULT(null), STALE("stale"), CONSISTENT("consistent"), CACHED("cached");
 
     private String param;
 

--- a/src/main/java/com/orbitz/consul/option/ConsistencyMode.java
+++ b/src/main/java/com/orbitz/consul/option/ConsistencyMode.java
@@ -89,6 +89,15 @@ public class ConsistencyMode {
         return name;
     }
 
+    @Override
+    public final String toString() {
+        String s = name();
+        for (Map.Entry<String, String> en : getAdditionalHeaders().entrySet()) {
+            s += String.format("[%s=%s]", en.getKey(), en.getValue());
+        }
+        return s;
+    }
+
     public int ordinal(){
         return ordinal;
     }

--- a/src/main/java/com/orbitz/consul/option/ParamAdder.java
+++ b/src/main/java/com/orbitz/consul/option/ParamAdder.java
@@ -5,4 +5,6 @@ import java.util.Map;
 public interface ParamAdder {
 
     Map<String, Object> toQuery();
+
+    Map<String, String> toHeaders();
 }

--- a/src/main/java/com/orbitz/consul/option/QueryOptions.java
+++ b/src/main/java/com/orbitz/consul/option/QueryOptions.java
@@ -99,13 +99,9 @@ public abstract class QueryOptions implements ParamAdder {
     public Map<String, Object> toQuery() {
         Map<String, Object> result = new HashMap<>();
 
-        switch (getConsistencyMode()) {
-            case CONSISTENT:
-                result.put("consistent", "");
-                break;
-            case STALE:
-                result.put("stale", "");
-                break;
+        Optional<String> consistency = getConsistencyMode().toParam();
+        if (consistency.isPresent()) {
+            result.put(consistency.get(), "");
         }
 
         if (isBlocking()) {
@@ -119,5 +115,10 @@ public abstract class QueryOptions implements ParamAdder {
         optionallyAdd(result, "dc", getDatacenter());
 
         return result;
+    }
+
+    @Override
+    public Map<String, String> toHeaders() {
+        return getConsistencyMode().getAdditionalHeaders();
     }
 }

--- a/src/main/java/com/orbitz/consul/option/TransactionOptions.java
+++ b/src/main/java/com/orbitz/consul/option/TransactionOptions.java
@@ -34,4 +34,12 @@ public abstract class TransactionOptions implements ParamAdder {
 
         return result;
     }
+
+    public Map<String, String> toHeaders() {
+        Map<String, String> result = new HashMap<>();
+
+        ConsistencyMode consistencyMode = getConsistencyMode();
+        result.putAll(consistencyMode.getAdditionalHeaders());
+        return result;
+    }
 }

--- a/src/main/java/com/orbitz/consul/util/Http.java
+++ b/src/main/java/com/orbitz/consul/util/Http.java
@@ -1,6 +1,7 @@
 package com.orbitz.consul.util;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
 import com.orbitz.consul.ConsulException;
 import com.orbitz.consul.async.Callback;
@@ -121,7 +122,7 @@ public class Http {
         BigInteger index = indexHeaderValue == null ? BigInteger.ZERO : new BigInteger(indexHeaderValue);
         long lastContact = lastContactHeaderValue == null ? 0 : NumberUtils.toLong(lastContactHeaderValue);
         boolean knownLeader = knownLeaderHeaderValue == null ? false : Boolean.valueOf(knownLeaderHeaderValue);
-
-        return new ConsulResponse<>(response.body(), lastContact, knownLeader, index);
+        return new ConsulResponse<>(response.body(), lastContact, knownLeader, index,
+                                    headers.get("X-Cache"), headers.get("Age"));
     }
 }

--- a/src/test/java/com/orbitz/consul/cache/AsyncCallbackConsumer.java
+++ b/src/test/java/com/orbitz/consul/cache/AsyncCallbackConsumer.java
@@ -24,7 +24,7 @@ public class AsyncCallbackConsumer implements ConsulCache.CallbackConsumer<Value
     public void consume(BigInteger index, final ConsulResponseCallback<List<Value>> callback) {
         callCount++;
         thread = new Thread(() -> {
-            callback.onComplete(new ConsulResponse<List<Value>>(result, 0, true, BigInteger.ZERO));
+            callback.onComplete(new ConsulResponse<List<Value>>(result, 0, true, BigInteger.ZERO, null, null));
         });
         thread.setName("asyncCallbackConsumer");
 

--- a/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
@@ -52,7 +52,7 @@ public class ConsulCacheTest {
         final StubCallbackConsumer callbackConsumer = new StubCallbackConsumer(Collections.emptyList());
 
         final ConsulCache<String, Value> consulCache = new ConsulCache<>(keyExtractor, callbackConsumer, cacheConfig, eventHandler, new CacheDescriptor(""));
-        final ConsulResponse<List<Value>> consulResponse = new ConsulResponse<>(response, 0, false, BigInteger.ONE);
+        final ConsulResponse<List<Value>> consulResponse = new ConsulResponse<>(response, 0, false, BigInteger.ONE, null, null);
         final ImmutableMap<String, Value> map = consulCache.convertToMap(consulResponse);
         assertNotNull(map);
         // Second copy has been weeded out

--- a/src/test/java/com/orbitz/consul/cache/StubCallbackConsumer.java
+++ b/src/test/java/com/orbitz/consul/cache/StubCallbackConsumer.java
@@ -23,7 +23,7 @@ public class StubCallbackConsumer implements ConsulCache.CallbackConsumer<Value>
     @Override
     public void consume(BigInteger index, ConsulResponseCallback<List<Value>> callback) {
         callCount++;
-        callback.onComplete(new ConsulResponse<>(result, 0, true, BigInteger.ZERO));
+        callback.onComplete(new ConsulResponse<>(result, 0, true, BigInteger.ZERO, null, null));
     }
 
     public int getCallCount() {

--- a/src/test/java/com/orbitz/consul/config/CacheConfigTest.java
+++ b/src/test/java/com/orbitz/consul/config/CacheConfigTest.java
@@ -15,7 +15,6 @@ import org.slf4j.Logger;
 import java.math.BigInteger;
 import java.time.Duration;
 import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -215,7 +214,7 @@ public class CacheConfigTest {
             CacheDescriptor cacheDescriptor = new CacheDescriptor("test", "test");
 
             final CallbackConsumer<Integer> callbackConsumer = (index, callback) -> {
-                callback.onComplete(new ConsulResponse<>(res.get(), 0, true, BigInteger.ZERO));
+                callback.onComplete(new ConsulResponse<>(res.get(), 0, true, BigInteger.ZERO, null, null));
             };
 
             return new TestCache((i) -> i,

--- a/src/test/java/com/orbitz/consul/option/ConsistencyModeTest.java
+++ b/src/test/java/com/orbitz/consul/option/ConsistencyModeTest.java
@@ -1,0 +1,53 @@
+package com.orbitz.consul.option;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Optional;
+
+public class ConsistencyModeTest {
+
+    @Test
+    public void checkCompatinbilityWithOldEnum(){
+        assertEquals(ConsistencyMode.values().length, 3);
+        for (int i = 0; i < ConsistencyMode.values().length; i++) {
+            assertEquals(ConsistencyMode.values()[i].ordinal(), i);
+        }
+        assertEquals(ConsistencyMode.values()[0], ConsistencyMode.DEFAULT);
+        assertEquals(ConsistencyMode.values()[0].name(), "DEFAULT");
+        assertEquals(ConsistencyMode.values()[1], ConsistencyMode.STALE);
+        assertEquals(ConsistencyMode.values()[1].name(), "STALE");
+        assertEquals(ConsistencyMode.values()[2], ConsistencyMode.CONSISTENT);
+        assertEquals(ConsistencyMode.values()[2].name(), "CONSISTENT");
+    }
+
+    @Test
+    public void checkHeadersForCached() {
+        ConsistencyMode consistency = ConsistencyMode.createCachedConsistencyWithMaxAgeAndStale(Optional.of(Long.valueOf(30)), Optional.of(60L));
+        assertEquals("cached", consistency.toParam().get());
+        assertEquals(1, consistency.getAdditionalHeaders().size());
+        assertEquals("max-age=30,stale-if-error=60", consistency.getAdditionalHeaders().get("Cache-Control"));
+
+        consistency = ConsistencyMode.createCachedConsistencyWithMaxAgeAndStale(Optional.of(30L), Optional.empty());
+        assertEquals("max-age=30", consistency.getAdditionalHeaders().get("Cache-Control"));
+
+        consistency = ConsistencyMode.createCachedConsistencyWithMaxAgeAndStale(Optional.empty(), Optional.of(60L));
+        assertEquals("stale-if-error=60", consistency.getAdditionalHeaders().get("Cache-Control"));
+
+        // Consistency cache without Cache-Control directives
+        consistency = ConsistencyMode.createCachedConsistencyWithMaxAgeAndStale(Optional.empty(), Optional.empty());
+        assertEquals("cached", consistency.toParam().get());
+        assertEquals(0, consistency.getAdditionalHeaders().size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkBadMaxAge() {
+        ConsistencyMode.createCachedConsistencyWithMaxAgeAndStale(Optional.of(-1L), Optional.empty());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkBadMaxStaleError() {
+        ConsistencyMode.createCachedConsistencyWithMaxAgeAndStale(Optional.empty(), Optional.of(-2L));
+    }
+}

--- a/src/test/java/com/orbitz/consul/util/HttpTest.java
+++ b/src/test/java/com/orbitz/consul/util/HttpTest.java
@@ -288,7 +288,7 @@ public class HttpTest {
     @Test
     public void consulResponseShouldHaveResponseAndDefaultValuesIfNoHeader() {
         String responseMessage = "success";
-        ConsulResponse<String> expectedConsulResponse = new ConsulResponse<>(responseMessage, 0, false, BigInteger.ZERO);
+        ConsulResponse<String> expectedConsulResponse = new ConsulResponse<>(responseMessage, 0, false, BigInteger.ZERO, null, null);
 
         Response<String> response = Response.success(responseMessage);
         ConsulResponse<String> consulResponse = Http.consulResponse(response);

--- a/src/test/java/com/orbitz/consul/util/failover/strategy/BlacklistingConsulFailoverStrategyTest.java
+++ b/src/test/java/com/orbitz/consul/util/failover/strategy/BlacklistingConsulFailoverStrategyTest.java
@@ -11,7 +11,6 @@ import java.util.Collection;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
 
 public class BlacklistingConsulFailoverStrategyTest {
     private BlacklistingConsulFailoverStrategy blacklistingConsulFailoverStrategy;


### PR DESCRIPTION
Many endpoints including health now support cached results, aka
the local Consul agent will sync with the servers to get updates.

This includes support for this mode, especially useful when several
applications are using the same services.

See https://www.consul.io/api/features/caching.html