### PR TITLE
Added serialization inclusion of non-null, non-absent, and non-empty …

### DIFF
--- a/src/main/java/com/orbitz/consul/util/Jackson.java
+++ b/src/main/java/com/orbitz/consul/util/Jackson.java
@@ -1,5 +1,6 @@
 package com.orbitz.consul.util;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -12,6 +13,9 @@ public class Jackson {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new Jdk8Module());
         mapper.registerModule(new GuavaModule());
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         return mapper;
     }
 


### PR DESCRIPTION
…to work with Consul breaking API change in 1.7.0 via https://github.com/hashicorp/consul/pull/6874

The client uses the same classes, for example Check, to set and get checks in Consul. The current Jackson ObjectMapper configuration serializes null and empty values when sending requests. With a recent API breaking change in Consul v1.7.0, see https://github.com/hashicorp/consul/blob/master/CHANGELOG.md, these null fields that shouldn't be used in requests are being rejected. This change simply turns on Jackson's support to only serialize non-null, non-empty, and non-absent values. From my quick testing this appears to resolve the immediate issue.

A concrete example is the "Output" field of Check. This is only used in a response and not when creating a check and therefore causes a 400 response from Consul when sent in v1.7.0+.

A better long term fix may be for consul-client to use request and response specific objects rather than a single object, such as Check, for creating and getting checks or to add more specific Jackson annotations on fields when used for requests vs responses.