### PR TITLE
Upgrade to guava.version 29.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <apache.commons.version>3.8.1</apache.commons.version>
         <commonscodec.version>1.12</commonscodec.version>
         <findbugs.version>1.3.9</findbugs.version>
-        <guava.version>27.1-jre</guava.version>
+        <guava.version>29.0-jre</guava.version>
         <immutables.version>2.7.5</immutables.version>
         <jackson.version>2.9.10</jackson.version>
         <junit.version>4.12</junit.version>

--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -122,10 +122,10 @@ public class ConsulCache<K, V> implements AutoCloseable {
                     if (!isRunning()) {
                         return;
                     }
-                    Duration elapsedTime = stopWatch.elapsed();
+                    long elapsedTime = stopWatch.elapsed(TimeUnit.MILLISECONDS);
                     updateIndex(consulResponse);
                     LOGGER.debug("Consul cache updated for {} (index={}), request duration: {} ms",
-                            cacheDescriptor, latestIndex, elapsedTime.toMillis());
+                            cacheDescriptor, latestIndex, elapsedTime);
 
                     ImmutableMap<K, V> full = convertToMap(consulResponse);
 


### PR DESCRIPTION
This upgrade is required to solve dependencies conflict with spring-consul  project  which uses higher version 
changes required to pass TimeUnit to elapsed stopWatch.elapsed(TimeUnit.MILLISECONDS)
returning long instead of Duration  