### PR TITLE
Expose 'Meta' property on Agent model

### DIFF
--- a/src/main/java/com/orbitz/consul/model/agent/Agent.java
+++ b/src/main/java/com/orbitz/consul/model/agent/Agent.java
@@ -25,4 +25,6 @@ public abstract class Agent {
     @JsonProperty("Member")
     public abstract Member getMember();
 
+    @JsonProperty("Meta")
+    public abstract Map<String, String> getMeta();
 }


### PR DESCRIPTION
See https://www.consul.io/api-docs/agent#read-configuration, /self/agent exposes a "Meta" property.

In order to access those metadata when using the lib, we can expose the property here at Agent.