### PR TITLE
#436 ServiceWeights should be just Weights for agent api

### DIFF
--- a/src/main/java/com/orbitz/consul/model/agent/Registration.java
+++ b/src/main/java/com/orbitz/consul/model/agent/Registration.java
@@ -51,7 +51,7 @@ public abstract class Registration {
     @JsonProperty("EnableTagOverride")
     public abstract Optional<Boolean> getEnableTagOverride();
 
-    @JsonProperty("ServiceWeights")
+    @JsonProperty("Weights")
     public abstract Optional<ServiceWeights> getServiceWeights();
 
     @Value.Immutable


### PR DESCRIPTION
Fixing https://github.com/rickfast/consul-client/issues/436
ServiceWeights should be called Weights according to the latest agent api docs https://www.consul.io/api-docs/agent/service#register-service
I've only renamed jsonProperty and not the field itself for backwards compatibility (that's open for debate though).
Tested the fix by running integration tests.

Note: to run tests I also had to fix a compilation error in ConsulCache on line 125, though not sure if that's something to do with my local environment. Only including ServiceWeights fix with this PR.