### PR TITLE
Add namespace support through query options.

### DIFF
--- a/src/main/java/com/orbitz/consul/option/QueryOptions.java
+++ b/src/main/java/com/orbitz/consul/option/QueryOptions.java
@@ -27,6 +27,7 @@ public abstract class QueryOptions implements ParamAdder {
     public abstract Optional<BigInteger> getIndex();
     public abstract Optional<String> getNear();
     public abstract Optional<String> getDatacenter();
+    public abstract Optional<String> getNamespace();
     public abstract List<String> getNodeMeta();
     public abstract List<String> getTag();
 
@@ -113,6 +114,7 @@ public abstract class QueryOptions implements ParamAdder {
         optionallyAdd(result, "token", getToken());
         optionallyAdd(result, "near", getNear());
         optionallyAdd(result, "dc", getDatacenter());
+        optionallyAdd(result, "ns", getNamespace());
 
         return result;
     }


### PR DESCRIPTION
[Namespace](https://www.consul.io/docs/enterprise/namespaces) is a consul enterprise feature that adds another dimension to group services. A request can target a namespace by either supplying `X-Consul-Namespace` header or the `ns` URL parameter (similar to `dc`). 

This changeset adds `Namespace` to `QueryOptions` facilitating clients to target API calls to a particular namespace. Setting the field adds `ns` to the query parameter.

Regression is minimal as it's a new field and set only if a value is present.

Ref: https://www.consul.io/api-docs/catalog