### PR TITLE
Add optional fields to checks during registration

### DIFF
--- a/src/itest/java/com/orbitz/consul/AgentITest.java
+++ b/src/itest/java/com/orbitz/consul/AgentITest.java
@@ -127,6 +127,72 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     @Ignore
+    public void shouldRegisterCheckWithId() throws UnknownHostException, InterruptedException {
+        String serviceName = UUID.randomUUID().toString();
+        String serviceId = UUID.randomUUID().toString();
+        String checkId = UUID.randomUUID().toString();
+
+        Registration registration = ImmutableRegistration.builder()
+                .name(serviceName)
+                .id(serviceId)
+                .addChecks(ImmutableRegCheck.builder()
+                        .id(checkId)
+                        .ttl("10s")
+                        .build())
+                .build();
+
+        client.agentClient().register(registration);
+
+        Synchroniser.pause(Duration.ofMillis(100));
+
+        boolean found = false;
+
+        for (ServiceHealth health : client.healthClient().getAllServiceInstances(serviceName).getResponse()) {
+            if (health.getService().getId().equals(serviceId)) {
+                found = true;
+                assertThat(health.getChecks().size(), is(2));
+                assertTrue(health.getChecks().stream().anyMatch(check -> check.getCheckId().equals(checkId)));
+            }
+        }
+
+        assertTrue(found);
+    }
+
+    @Test
+    @Ignore
+    public void shouldRegisterCheckWithName() throws UnknownHostException, InterruptedException {
+        String serviceName = UUID.randomUUID().toString();
+        String serviceId = UUID.randomUUID().toString();
+        String checkName = UUID.randomUUID().toString();
+
+        Registration registration = ImmutableRegistration.builder()
+                .name(serviceName)
+                .id(serviceId)
+                .addChecks(ImmutableRegCheck.builder()
+                        .name(checkName)
+                        .ttl("10s")
+                        .build())
+                .build();
+
+        client.agentClient().register(registration);
+
+        Synchroniser.pause(Duration.ofMillis(100));
+
+        boolean found = false;
+
+        for (ServiceHealth health : client.healthClient().getAllServiceInstances(serviceName).getResponse()) {
+            if (health.getService().getId().equals(serviceId)) {
+                found = true;
+                assertThat(health.getChecks().size(), is(2));
+                assertTrue(health.getChecks().stream().anyMatch(check -> check.getName().equals(checkName)));
+            }
+        }
+
+        assertTrue(found);
+    }
+
+    @Test
+    @Ignore
     public void shouldRegisterMultipleChecks() throws UnknownHostException, InterruptedException, MalformedURLException {
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();

--- a/src/main/java/com/orbitz/consul/model/agent/Registration.java
+++ b/src/main/java/com/orbitz/consul/model/agent/Registration.java
@@ -60,6 +60,12 @@ public abstract class Registration {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public abstract static class RegCheck {
 
+        @JsonProperty("CheckID")
+        public abstract Optional<String> getId();
+
+        @JsonProperty("Name")
+        public abstract Optional<String> getName();
+
         @JsonProperty("Args")
         public abstract Optional<List<String>> getArgs();
 


### PR DESCRIPTION
It was possible to assign Check ID and Name in Check but not RegCheck. This MR adds two optional fields as in [https://www.consul.io/api-docs/agent/service#check](https://www.consul.io/api-docs/agent/service#check)