### PR TITLE
Changed end point accessed with ping to one without ACL requirements

### DIFF
--- a/src/main/java/com/orbitz/consul/AgentClient.java
+++ b/src/main/java/com/orbitz/consul/AgentClient.java
@@ -681,7 +681,7 @@ public class AgentClient extends BaseClient {
         @PUT("agent/check/deregister/{checkId}")
         Call<Void> deregisterCheck(@Path("checkId") String checkId);
 
-        @GET("agent/self")
+        @GET("status/leader")
         Call<Void> ping();
 
         @GET("agent/self")


### PR DESCRIPTION
Changed according to suggestion in #421 
Because [agent/self](https://www.consul.io/api-docs/agent#read-configuration) needs ACL agent:read privilege,
change it to [status/leader](https://www.consul.io/api-docs/status#get-raft-leader) that requires none