### PR TITLE
Add filter option

### DIFF
--- a/src/main/java/com/orbitz/consul/AgentClient.java
+++ b/src/main/java/com/orbitz/consul/AgentClient.java
@@ -434,7 +434,19 @@ public class AgentClient extends BaseClient {
      * @return Map of Service ID to Services.
      */
     public Map<String, Service> getServices() {
-        return http.extract(api.getServices());
+        return getServices(QueryOptions.BLANK);
+    }
+
+    /**
+     * Retrieves all services registered with the Agent.
+     * <p/>
+     * GET /v1/agent/services
+     *
+     * @param queryOptions The Query Options to use.
+     * @return Map of Service ID to Services.
+     */
+    public Map<String, Service> getServices(QueryOptions queryOptions) {
+        return http.extract(api.getServices(queryOptions.toQuery()));
     }
 
     /**
@@ -691,7 +703,7 @@ public class AgentClient extends BaseClient {
         Call<Map<String, HealthCheck>> getChecks();
 
         @GET("agent/services")
-        Call<Map<String, Service>> getServices();
+        Call<Map<String, Service>> getServices(@QueryMap Map<String, Object> query);
 
         @GET("agent/service/{id}")
         Call<FullService> getService(@Path("id") String id, @QueryMap Map<String, Object> query);

--- a/src/main/java/com/orbitz/consul/option/QueryOptions.java
+++ b/src/main/java/com/orbitz/consul/option/QueryOptions.java
@@ -27,6 +27,7 @@ public abstract class QueryOptions implements ParamAdder {
     public abstract Optional<BigInteger> getIndex();
     public abstract Optional<String> getNear();
     public abstract Optional<String> getDatacenter();
+    public abstract Optional<String> getFilter();
     public abstract List<String> getNodeMeta();
     public abstract List<String> getTag();
 
@@ -113,6 +114,7 @@ public abstract class QueryOptions implements ParamAdder {
         optionallyAdd(result, "token", getToken());
         optionallyAdd(result, "near", getNear());
         optionallyAdd(result, "dc", getDatacenter());
+        optionallyAdd(result, "filter", getFilter());
 
         return result;
     }


### PR DESCRIPTION
Add possibility to pass filter option in query.
Also allows to pass query options object for listing services call as in
[https://www.consul.io/api-docs/agent/service#list-services](https://www.consul.io/api-docs/agent/service#list-services)
Suggested in #401 