### PR TITLE
Add support for ACL Role

### DIFF
--- a/src/main/java/com/orbitz/consul/AclClient.java
+++ b/src/main/java/com/orbitz/consul/AclClient.java
@@ -3,11 +3,13 @@ package com.orbitz.consul;
 import com.orbitz.consul.config.ClientConfig;
 import com.orbitz.consul.model.acl.*;
 import com.orbitz.consul.monitoring.ClientEventCallback;
+import com.orbitz.consul.option.RoleOptions;
 import retrofit2.Call;
 import retrofit2.Retrofit;
 import retrofit2.http.*;
 
 import java.util.List;
+import java.util.Map;
 
 public class AclClient extends BaseClient {
 
@@ -88,6 +90,34 @@ public class AclClient extends BaseClient {
         http.extract(api.deleteToken(id));
     }
 
+    public RoleResponse createRole(Role token) {
+        return http.extract(api.createRole(token));
+    }
+
+    public RoleResponse readRole(String id) {
+        return http.extract(api.readRole(id));
+    }
+
+    public RoleResponse readRoleByName(String name) {
+        return http.extract(api.readRoleByName(name));
+    }
+
+    public RoleResponse updateRole(String id, Role role) {
+        return http.extract(api.updateRole(id, role));
+    }
+
+    public List<RoleListResponse> listRoles() {
+        return listRoles(RoleOptions.BLANK);
+    }
+
+    public List<RoleListResponse> listRoles(RoleOptions roleOptions) {
+        return http.extract(api.listRoles(roleOptions.toQuery()));
+    }
+
+    public void deleteRole(String id) {
+        http.extract(api.deleteRole(id));
+    }
+
     interface Api {
 
         @PUT("acl/create")
@@ -137,6 +167,24 @@ public class AclClient extends BaseClient {
 
         @DELETE("acl/token/{id}")
         Call<Void> deleteToken(@Path("id") String id);
+
+        @PUT("acl/role")
+        Call<RoleResponse> createRole(@Body Role role);
+
+        @GET("acl/role/{id}")
+        Call<RoleResponse> readRole(@Path("id") String id);
+
+        @GET("acl/role/name/{name}")
+        Call<RoleResponse> readRoleByName(@Path("name") String name);
+
+        @PUT("acl/role/{id}")
+        Call<RoleResponse> updateRole(@Path("id") String id, @Body Role role);
+
+        @DELETE("acl/role/{id}")
+        Call<Void> deleteRole(@Path("id") String id);
+
+        @GET("acl/roles")
+        Call<List<RoleListResponse>> listRoles(@QueryMap Map<String, Object> query);
     }
 
 }

--- a/src/main/java/com/orbitz/consul/model/acl/BaseRoleResponse.java
+++ b/src/main/java/com/orbitz/consul/model/acl/BaseRoleResponse.java
@@ -1,0 +1,38 @@
+package com.orbitz.consul.model.acl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigInteger;
+import java.util.Date;
+import java.util.List;
+
+public abstract class BaseRoleResponse {
+
+    @JsonProperty("ID")
+    public abstract String id();
+
+    @JsonProperty("Name")
+    public abstract String name();
+
+    @JsonProperty("Description")
+    public abstract String description();
+
+    @JsonProperty("Policies")
+    public abstract List<Role.RolePolicyLink> policies();
+
+    @JsonProperty("ServiceIdentities")
+    public abstract List<Role.RoleServiceIdentity> serviceIdentities();
+
+    @JsonProperty("NodeIdentities")
+    public abstract List<Role.RoleNodeIdentity> nodeIdentities();
+
+    @JsonProperty("CreateIndex")
+    public abstract BigInteger createIndex();
+
+    @JsonProperty("ModifyIndex")
+    public abstract BigInteger modifyIndex();
+
+    @JsonProperty("Hash")
+    public abstract String hash();
+
+}

--- a/src/main/java/com/orbitz/consul/model/acl/Role.java
+++ b/src/main/java/com/orbitz/consul/model/acl/Role.java
@@ -1,0 +1,83 @@
+package com.orbitz.consul.model.acl;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.ImmutableList;
+import org.immutables.value.Value;
+
+import java.util.List;
+import java.util.Optional;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableRole.class)
+@JsonDeserialize(as = ImmutableRole.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class Role {
+
+    @JsonProperty("Name")
+    public abstract String name();
+
+    @JsonProperty("ID")
+    public abstract Optional<String> id();
+
+    @JsonProperty("Description")
+    public abstract Optional<String> description();
+
+    @JsonProperty("Policies")
+    @JsonDeserialize(as = ImmutableList.class, contentAs = RolePolicyLink.class)
+    public abstract List<RolePolicyLink> policies();
+
+    @JsonProperty("ServiceIdentities")
+    @JsonDeserialize(as = ImmutableList.class, contentAs = RoleServiceIdentity.class)
+    public abstract List<RoleServiceIdentity> serviceIdentities();
+
+    @JsonProperty("NodeIdentities")
+    @JsonDeserialize(as = ImmutableList.class, contentAs = RoleNodeIdentity.class)
+    public abstract List<RoleNodeIdentity> nodeIdentities();
+
+    @JsonProperty("Namespace")
+    public abstract Optional<String> namespace();
+
+    @Value.Immutable
+    @JsonSerialize(as = ImmutableRolePolicyLink.class)
+    @JsonDeserialize(as = ImmutableRolePolicyLink.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public abstract static class RolePolicyLink {
+
+        @JsonProperty("ID")
+        public abstract Optional<String> id();
+
+        @JsonProperty("Name")
+        public abstract Optional<String> name();
+    }
+
+    @Value.Immutable
+    @JsonSerialize(as = ImmutableRoleServiceIdentity.class)
+    @JsonDeserialize(as = ImmutableRoleServiceIdentity.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public abstract static class RoleServiceIdentity {
+
+        @JsonProperty("ServiceName")
+        public abstract String name();
+
+        @JsonProperty("Datacenters")
+        @JsonDeserialize(as = ImmutableList.class, contentAs = String.class)
+        public abstract List<String> datacenters();
+    }
+
+    @Value.Immutable
+    @JsonSerialize(as = ImmutableRoleNodeIdentity.class)
+    @JsonDeserialize(as = ImmutableRoleNodeIdentity.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public abstract static class RoleNodeIdentity {
+
+        @JsonProperty("NodeName")
+        public abstract String name();
+
+        @JsonProperty("Datacenter")
+        public abstract String datacenter();
+    }
+}

--- a/src/main/java/com/orbitz/consul/model/acl/RoleListResponse.java
+++ b/src/main/java/com/orbitz/consul/model/acl/RoleListResponse.java
@@ -1,0 +1,13 @@
+package com.orbitz.consul.model.acl;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableRoleListResponse.class)
+@JsonDeserialize(as = ImmutableRoleListResponse.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class RoleListResponse extends BaseRoleResponse {
+}

--- a/src/main/java/com/orbitz/consul/model/acl/RoleResponse.java
+++ b/src/main/java/com/orbitz/consul/model/acl/RoleResponse.java
@@ -1,0 +1,14 @@
+package com.orbitz.consul.model.acl;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableRoleResponse.class)
+@JsonDeserialize(as = ImmutableRoleResponse.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class RoleResponse extends BaseRoleResponse {
+}

--- a/src/main/java/com/orbitz/consul/option/RoleOptions.java
+++ b/src/main/java/com/orbitz/consul/option/RoleOptions.java
@@ -1,0 +1,33 @@
+package com.orbitz.consul.option;
+
+import com.google.common.collect.ImmutableList;
+import org.immutables.value.Value;
+
+import java.math.BigInteger;
+import java.util.*;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.orbitz.consul.option.Options.optionallyAdd;
+
+/**
+ * Container for common query options used by the Consul API.
+ */
+@Value.Immutable
+public abstract class RoleOptions implements ParamAdder {
+
+    public static final RoleOptions BLANK = ImmutableRoleOptions.builder().build();
+
+    public abstract Optional<String> getPolicy();
+    public abstract Optional<String> getNamespace();
+
+
+    @Override
+    public Map<String, Object> toQuery() {
+        Map<String, Object> result = new HashMap<>();
+
+        optionallyAdd(result, "policy", getPolicy());
+        optionallyAdd(result, "ns", getNamespace());
+
+        return result;
+    }
+}


### PR DESCRIPTION
Adds support for ACL Role end points.

I didn't want to reuse PolicyLink/ServiceIdentity/NodeIdentity from Token because 
1. Some of them don't exist yet
2. There were some problems with generated classes when I tried to include them in two classes
so Role has it's own RolePolicyLink/RoleServiceIdentity/RoleNodeIdentity

Added also some simple tests to at least verify that it works