### PR TITLE
start cache from specific index

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/NodesCatalogCache.java
+++ b/src/main/java/com/orbitz/consul/cache/NodesCatalogCache.java
@@ -6,6 +6,7 @@ import com.orbitz.consul.config.CacheConfig;
 import com.orbitz.consul.model.health.Node;
 import com.orbitz.consul.option.QueryOptions;
 
+import java.math.BigInteger;
 import java.util.concurrent.ScheduledExecutorService;
 
 public class NodesCatalogCache extends ConsulCache<String, Node> {
@@ -13,7 +14,8 @@ public class NodesCatalogCache extends ConsulCache<String, Node> {
     private NodesCatalogCache(CatalogClient catalogClient,
                               QueryOptions queryOptions,
                               int watchSeconds,
-                              Scheduler callbackScheduler) {
+                              Scheduler callbackScheduler,
+                              BigInteger initialIndex) {
         super(Node::getNode,
               (index, callback) -> {
                   checkWatch(catalogClient.getNetworkTimeoutConfig().getClientReadTimeoutMillis(), watchSeconds);
@@ -22,7 +24,8 @@ public class NodesCatalogCache extends ConsulCache<String, Node> {
               catalogClient.getConfig().getCacheConfig(),
               catalogClient.getEventHandler(),
               new CacheDescriptor("catalog.nodes"),
-              callbackScheduler);
+              callbackScheduler,
+              initialIndex);
     }
 
     public static NodesCatalogCache newCache(
@@ -32,16 +35,36 @@ public class NodesCatalogCache extends ConsulCache<String, Node> {
             final ScheduledExecutorService callbackExecutorService) {
 
         Scheduler scheduler = createExternal(callbackExecutorService);
-        return new NodesCatalogCache(catalogClient, queryOptions, watchSeconds, scheduler);
+        return new NodesCatalogCache(catalogClient, queryOptions, watchSeconds, scheduler, null);
+    }
+
+    public static NodesCatalogCache newCache(
+            CatalogClient catalogClient,
+            QueryOptions queryOptions,
+            int watchSeconds,
+            BigInteger initialIndex,
+            ScheduledExecutorService callbackExecutorService) {
+
+        Scheduler scheduler = createExternal(callbackExecutorService);
+        return new NodesCatalogCache(catalogClient, queryOptions, watchSeconds, scheduler, initialIndex);
     }
 
     public static NodesCatalogCache newCache(
             final CatalogClient catalogClient,
             final QueryOptions queryOptions,
             final int watchSeconds) {
-        return new NodesCatalogCache(catalogClient, queryOptions, watchSeconds, createDefault());
+        return new NodesCatalogCache(catalogClient, queryOptions, watchSeconds, createDefault(), null);
     }
 
+    public static NodesCatalogCache newCache(
+        CatalogClient catalogClient,
+        QueryOptions queryOptions,
+        int watchSeconds,
+        BigInteger initialIndex) {
+        return new NodesCatalogCache(catalogClient, queryOptions, watchSeconds, createDefault(), initialIndex);
+    }
+
+    @Deprecated
     public static NodesCatalogCache newCache(final CatalogClient catalogClient) {
         CacheConfig cacheConfig = catalogClient.getConfig().getCacheConfig();
         int watchSeconds = Ints.checkedCast(cacheConfig.getWatchDuration().getSeconds());

--- a/src/main/java/com/orbitz/consul/cache/ServiceCatalogCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ServiceCatalogCache.java
@@ -5,6 +5,7 @@ import com.orbitz.consul.CatalogClient;
 import com.orbitz.consul.config.CacheConfig;
 import com.orbitz.consul.model.catalog.CatalogService;
 import com.orbitz.consul.option.QueryOptions;
+import java.math.BigInteger;
 import java.util.concurrent.ScheduledExecutorService;
 
 public class ServiceCatalogCache extends ConsulCache<String, CatalogService> {
@@ -13,7 +14,8 @@ public class ServiceCatalogCache extends ConsulCache<String, CatalogService> {
                                 String serviceName,
                                 QueryOptions queryOptions,
                                 int watchSeconds,
-                                Scheduler callbackScheduler) {
+                                Scheduler callbackScheduler,
+                                BigInteger initialIndex) {
 
         super(CatalogService::getServiceId,
             (index, callback) -> {
@@ -23,7 +25,8 @@ public class ServiceCatalogCache extends ConsulCache<String, CatalogService> {
             catalogClient.getConfig().getCacheConfig(),
             catalogClient.getEventHandler(),
             new CacheDescriptor("catalog.service", serviceName),
-            callbackScheduler);
+            callbackScheduler,
+            initialIndex);
     }
 
     public static ServiceCatalogCache newCache(
@@ -34,7 +37,19 @@ public class ServiceCatalogCache extends ConsulCache<String, CatalogService> {
             final ScheduledExecutorService callbackExecutorService) {
 
         Scheduler scheduler = createExternal(callbackExecutorService);
-        return new ServiceCatalogCache(catalogClient, serviceName, queryOptions, watchSeconds, scheduler);
+        return new ServiceCatalogCache(catalogClient, serviceName, queryOptions, watchSeconds, scheduler, null);
+    }
+
+    public static ServiceCatalogCache newCache(
+            CatalogClient catalogClient,
+            String serviceName,
+            QueryOptions queryOptions,
+            int watchSeconds,
+            BigInteger initialIndex,
+            ScheduledExecutorService callbackExecutorService) {
+
+      Scheduler scheduler = createExternal(callbackExecutorService);
+      return new ServiceCatalogCache(catalogClient, serviceName, queryOptions, watchSeconds, scheduler, initialIndex);
     }
 
     public static ServiceCatalogCache newCache(
@@ -43,9 +58,20 @@ public class ServiceCatalogCache extends ConsulCache<String, CatalogService> {
             final QueryOptions queryOptions,
             final int watchSeconds) {
 
-        return new ServiceCatalogCache(catalogClient, serviceName, queryOptions, watchSeconds, createDefault());
+        return new ServiceCatalogCache(catalogClient, serviceName, queryOptions, watchSeconds, createDefault(), null);
     }
 
+    public static ServiceCatalogCache newCache(
+            CatalogClient catalogClient,
+            String serviceName,
+            QueryOptions queryOptions,
+            int watchSeconds,
+            BigInteger initialIndex) {
+
+      return new ServiceCatalogCache(catalogClient, serviceName, queryOptions, watchSeconds, createDefault(), initialIndex);
+    }
+
+    @Deprecated
     public static ServiceCatalogCache newCache(final CatalogClient catalogClient, final String serviceName) {
         CacheConfig cacheConfig = catalogClient.getConfig().getCacheConfig();
         int watchSeconds = Ints.checkedCast(cacheConfig.getWatchDuration().getSeconds());

--- a/src/test/java/com/orbitz/consul/cache/CountingCallsCallbackConsumer.java
+++ b/src/test/java/com/orbitz/consul/cache/CountingCallsCallbackConsumer.java
@@ -11,12 +11,12 @@ import java.util.List;
 /**
  *
  */
-public class StubCallbackConsumer implements ConsulCache.CallbackConsumer<Value> {
+public class CountingCallsCallbackConsumer implements ConsulCache.CallbackConsumer<Value> {
 
     private final List<Value> result;
     private int callCount;
 
-    public StubCallbackConsumer(List<Value> result) {
+    public CountingCallsCallbackConsumer(List<Value> result) {
         this.result = Collections.unmodifiableList(result);
     }
 

--- a/src/test/java/com/orbitz/consul/cache/IndexAwareStubCallbackConsumer.java
+++ b/src/test/java/com/orbitz/consul/cache/IndexAwareStubCallbackConsumer.java
@@ -1,0 +1,32 @@
+package com.orbitz.consul.cache;
+
+import com.orbitz.consul.async.ConsulResponseCallback;
+import com.orbitz.consul.model.ConsulResponse;
+import com.orbitz.consul.model.kv.Value;
+
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ *
+ */
+public class IndexAwareStubCallbackConsumer implements ConsulCache.CallbackConsumer<Value> {
+
+    private final List<Value> result;
+    private BigInteger index;
+
+    public IndexAwareStubCallbackConsumer(List<Value> result) {
+        this.result = Collections.unmodifiableList(result);
+    }
+
+    @Override
+    public void consume(BigInteger index, ConsulResponseCallback<List<Value>> callback) {
+        this.index = index;
+        callback.onComplete(new ConsulResponse<>(result, 0, true, BigInteger.ZERO, null, null));
+    }
+
+    public BigInteger getIndex() {
+        return index;
+    }
+}

--- a/src/test/java/com/orbitz/consul/config/CacheConfigTest.java
+++ b/src/test/java/com/orbitz/consul/config/CacheConfigTest.java
@@ -206,7 +206,7 @@ public class CacheConfigTest {
 
     static class TestCache extends ConsulCache<Integer, Integer> {
         private TestCache(Function<Integer, Integer> keyConversion, CallbackConsumer<Integer> callbackConsumer, CacheConfig cacheConfig, ClientEventHandler eventHandler, CacheDescriptor cacheDescriptor) {
-            super(keyConversion, callbackConsumer, cacheConfig, eventHandler, cacheDescriptor);
+            super(keyConversion, callbackConsumer, cacheConfig, eventHandler, cacheDescriptor, null);
         }
 
         static TestCache createCache(CacheConfig config, Supplier<List<Integer>> res) {


### PR DESCRIPTION
If you already have index for example from sync data load - there's no need to warmup cache - you can go with long polling from first request