### PR TITLE
Add test for ConsulResponse.toString

### DIFF
--- a/src/test/java/com/orbitz/consul/util/HttpTest.java
+++ b/src/test/java/com/orbitz/consul/util/HttpTest.java
@@ -319,4 +319,13 @@ public class HttpTest {
 
         assertEquals(true, consulResponse.isKnownLeader());
     }
+
+    @Test
+    public void testToString() {
+        String responseMessage = "success";
+        ConsulResponse<String> expectedConsulResponse = new ConsulResponse<>(responseMessage, 0, false, BigInteger.ZERO, null, null);
+        Response<String> response = Response.success(responseMessage);
+        ConsulResponse<String> consulResponse = Http.consulResponse(response);
+        assertEquals("ConsulResponse{response=success, lastContact=0, knownLeader=false, index=0, cache=Optional.empty}", consulResponse.toString());
+    }
 }


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that `consulResponse.toString()` is equal to `"ConsulResponse{response=success, lastContact=0, knownLeader=false, index=0, cache=Optional.empty}"`.
This tests the method [`ConsulResponse.toString`](https://github.com/rickfast/consul-client/blob/e7422ff833482f840939b8fb0ef12de5940266ca/src/main/java/com/orbitz/consul/model/ConsulResponse.java#L101).
This test is based on the test [`consulResponseShouldHaveResponseAndDefaultValuesIfNoHeader`](https://github.com/lacinoire/consul-client/blob/417910724c925d97081cd4249322f41541fd707c/src/test/java/com/orbitz/consul/util/HttpTest.java#L289).

Curious to hear what you think!

Also, is the description I provided of the test helping you to answer to this pull request? Why (not)?

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))