### PR TITLE
HH-157725 add path and responseCode parameters to ClientEventCallback interface methods

### DIFF
--- a/src/main/java/com/orbitz/consul/monitoring/ClientEventCallback.java
+++ b/src/main/java/com/orbitz/consul/monitoring/ClientEventCallback.java
@@ -6,11 +6,29 @@ import java.time.Duration;
 
 public interface ClientEventCallback {
 
+    /**
+     * @deprecated use {@link #onHttpRequestSuccess(String, String, String, String, int)} instead.
+     */
+    @Deprecated(forRemoval = true)
     default void onHttpRequestSuccess(String clientName, String method, String queryString) { }
 
+    default void onHttpRequestSuccess(String clientName, String method, String path, String queryString, int responseCode) { }
+
+    /**
+     * @deprecated use {@link #onHttpRequestFailure(String, String, String, String, Throwable)} instead.
+     */
+    @Deprecated(forRemoval = true)
     default void onHttpRequestFailure(String clientName, String method, String queryString, Throwable throwable) { }
 
+    default void onHttpRequestFailure(String clientName, String method, String path, String queryString, Throwable throwable) { }
+
+    /**
+     * @deprecated use {@link #onHttpRequestInvalid(String, String, String, String, int, Throwable)} instead.
+     */
+    @Deprecated(forRemoval = true)
     default void onHttpRequestInvalid(String clientName, String method, String queryString, Throwable throwable) { }
+
+    default void onHttpRequestInvalid(String clientName, String method, String path, String queryString, int responseCode, Throwable throwable) { }
 
     default void onCacheStart(String clientName, CacheDescriptor cacheDescriptor) { }
 

--- a/src/main/java/com/orbitz/consul/monitoring/ClientEventCallback.java
+++ b/src/main/java/com/orbitz/consul/monitoring/ClientEventCallback.java
@@ -9,26 +9,35 @@ public interface ClientEventCallback {
     /**
      * @deprecated use {@link #onHttpRequestSuccess(String, String, String, String, int)} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated
     default void onHttpRequestSuccess(String clientName, String method, String queryString) { }
 
-    default void onHttpRequestSuccess(String clientName, String method, String path, String queryString, int responseCode) { }
+    default void onHttpRequestSuccess(String clientName, String method, String path, String queryString, int responseCode) {
+        // Kept for compatibility at the moment
+        onHttpRequestSuccess(clientName, method, queryString);
+    }
 
     /**
      * @deprecated use {@link #onHttpRequestFailure(String, String, String, String, Throwable)} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated
     default void onHttpRequestFailure(String clientName, String method, String queryString, Throwable throwable) { }
 
-    default void onHttpRequestFailure(String clientName, String method, String path, String queryString, Throwable throwable) { }
+    default void onHttpRequestFailure(String clientName, String method, String path, String queryString, Throwable throwable) {
+        // Kept for compatibility at the moment
+        onHttpRequestFailure(clientName, method, queryString, throwable);
+    }
 
     /**
      * @deprecated use {@link #onHttpRequestInvalid(String, String, String, String, int, Throwable)} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated
     default void onHttpRequestInvalid(String clientName, String method, String queryString, Throwable throwable) { }
 
-    default void onHttpRequestInvalid(String clientName, String method, String path, String queryString, int responseCode, Throwable throwable) { }
+    default void onHttpRequestInvalid(String clientName, String method, String path, String queryString, int responseCode, Throwable throwable) {
+        // Kept for compatibility at the moment
+        onHttpRequestInvalid(clientName, method, queryString, throwable);
+    }
 
     default void onCacheStart(String clientName, CacheDescriptor cacheDescriptor) { }
 

--- a/src/main/java/com/orbitz/consul/monitoring/ClientEventHandler.java
+++ b/src/main/java/com/orbitz/consul/monitoring/ClientEventHandler.java
@@ -23,25 +23,22 @@ public class ClientEventHandler {
     }
 
     public void httpRequestSuccess(Request request, Response<?> response) {
-        EVENT_EXECUTOR.submit(() -> {
-            callback.onHttpRequestSuccess(clientName, request.method(), request.url().query());
-            callback.onHttpRequestSuccess(clientName, request.method(), request.url().encodedPath(), request.url().query(), response.code());
-        });
+        EVENT_EXECUTOR.submit(() ->
+            callback.onHttpRequestSuccess(clientName, request.method(), request.url().encodedPath(), request.url().query(), response.code())
+        );
     }
 
     public void httpRequestInvalid(Request request, Response<?> response, Throwable throwable) {
-        EVENT_EXECUTOR.submit(() -> {
-            callback.onHttpRequestInvalid(clientName, request.method(), request.url().query(), throwable);
+        EVENT_EXECUTOR.submit(() ->
             callback.onHttpRequestInvalid(clientName, request.method(), request.url().encodedPath(), request.url().query(), response.code(),
-                throwable);
-        });
+                throwable)
+        );
     }
 
     public void httpRequestFailure(Request request, Throwable throwable) {
-        EVENT_EXECUTOR.submit(() -> {
-            callback.onHttpRequestFailure(clientName, request.method(), request.url().query(), throwable);
-            callback.onHttpRequestFailure(clientName, request.method(), request.url().encodedPath(), request.url().query(), throwable);
-        });
+        EVENT_EXECUTOR.submit(() ->
+            callback.onHttpRequestFailure(clientName, request.method(), request.url().encodedPath(), request.url().query(), throwable)
+        );
     }
 
     public void cacheStart(CacheDescriptor cacheDescriptor) {

--- a/src/main/java/com/orbitz/consul/monitoring/ClientEventHandler.java
+++ b/src/main/java/com/orbitz/consul/monitoring/ClientEventHandler.java
@@ -2,14 +2,12 @@ package com.orbitz.consul.monitoring;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.orbitz.consul.cache.CacheDescriptor;
-import okhttp3.Request;
-
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import okhttp3.Request;
+import retrofit2.Response;
 
 public class ClientEventHandler {
 
@@ -24,18 +22,26 @@ public class ClientEventHandler {
         this.callback = callback;
     }
 
-    public void httpRequestSuccess(Request request) {
-        EVENT_EXECUTOR.submit(() -> callback.onHttpRequestSuccess(clientName, request.method(), request.url().query()));
+    public void httpRequestSuccess(Request request, Response<?> response) {
+        EVENT_EXECUTOR.submit(() -> {
+            callback.onHttpRequestSuccess(clientName, request.method(), request.url().query());
+            callback.onHttpRequestSuccess(clientName, request.method(), request.url().encodedPath(), request.url().query(), response.code());
+        });
     }
 
-    public void httpRequestInvalid(Request request, Throwable throwable) {
-        EVENT_EXECUTOR.submit(() ->
-                callback.onHttpRequestInvalid(clientName, request.method(), request.url().query(), throwable));
+    public void httpRequestInvalid(Request request, Response<?> response, Throwable throwable) {
+        EVENT_EXECUTOR.submit(() -> {
+            callback.onHttpRequestInvalid(clientName, request.method(), request.url().query(), throwable);
+            callback.onHttpRequestInvalid(clientName, request.method(), request.url().encodedPath(), request.url().query(), response.code(),
+                throwable);
+        });
     }
 
     public void httpRequestFailure(Request request, Throwable throwable) {
-        EVENT_EXECUTOR.submit(() ->
-                callback.onHttpRequestFailure(clientName, request.method(), request.url().query(), throwable));
+        EVENT_EXECUTOR.submit(() -> {
+            callback.onHttpRequestFailure(clientName, request.method(), request.url().query(), throwable);
+            callback.onHttpRequestFailure(clientName, request.method(), request.url().encodedPath(), request.url().query(), throwable);
+        });
     }
 
     public void cacheStart(CacheDescriptor cacheDescriptor) {

--- a/src/main/java/com/orbitz/consul/util/Http.java
+++ b/src/main/java/com/orbitz/consul/util/Http.java
@@ -1,20 +1,18 @@
 package com.orbitz.consul.util;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
 import com.orbitz.consul.ConsulException;
 import com.orbitz.consul.async.Callback;
 import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.ConsulResponse;
 import com.orbitz.consul.monitoring.ClientEventHandler;
+import java.io.IOException;
+import java.math.BigInteger;
 import okhttp3.Headers;
 import org.apache.commons.lang3.math.NumberUtils;
 import retrofit2.Call;
 import retrofit2.Response;
-
-import java.io.IOException;
-import java.math.BigInteger;
 
 public class Http {
 
@@ -56,10 +54,10 @@ public class Http {
 
     private <T> void ensureResponseSuccessful(Call<T> call, Response<T> response, Integer... okCodes) {
         if(isSuccessful(response, okCodes)) {
-            eventHandler.httpRequestSuccess(call.request());
+            eventHandler.httpRequestSuccess(call.request(), response);
         } else {
             ConsulException exception = new ConsulException(response.code(), response);
-            eventHandler.httpRequestInvalid(call.request(), exception);
+            eventHandler.httpRequestInvalid(call.request(), response, exception);
             throw exception;
         }
     }
@@ -76,11 +74,11 @@ public class Http {
             @Override
             public void onResponse(Call<T> call, Response<T> response) {
                 if (isSuccessful(response, okCodes)) {
-                    eventHandler.httpRequestSuccess(call.request());
+                    eventHandler.httpRequestSuccess(call.request(), response);
                     callback.onComplete(consulResponse(response));
                 } else {
                     ConsulException exception = new ConsulException(response.code(), response);
-                    eventHandler.httpRequestInvalid(call.request(), exception);
+                    eventHandler.httpRequestInvalid(call.request(), response, exception);
                     callback.onFailure(exception);
                 }
             }

--- a/src/test/java/com/orbitz/consul/util/HttpTest.java
+++ b/src/test/java/com/orbitz/consul/util/HttpTest.java
@@ -152,7 +152,7 @@ public class HttpTest {
 
         httpCall.apply(call);
 
-        verify(clientEventHandler, only()).httpRequestSuccess(any(Request.class));
+        verify(clientEventHandler, only()).httpRequestSuccess(any(Request.class), any(Response.class));
     }
 
     @Test
@@ -209,7 +209,7 @@ public class HttpTest {
             //ignore
         }
 
-        verify(clientEventHandler, only()).httpRequestInvalid(any(Request.class), any(Throwable.class));
+        verify(clientEventHandler, only()).httpRequestInvalid(any(Request.class), any(Response.class), any(Throwable.class));
     }
 
     @Test
@@ -237,7 +237,7 @@ public class HttpTest {
         latch.await(1, TimeUnit.SECONDS);
 
         assertEquals(expectedBody, result.get().getResponse());
-        verify(clientEventHandler, only()).httpRequestSuccess(any(Request.class));
+        verify(clientEventHandler, only()).httpRequestSuccess(any(Request.class), any(Response.class));
     }
 
     @Test
@@ -261,7 +261,7 @@ public class HttpTest {
         callCallback.onResponse(call, response);
         latch.await(1, TimeUnit.SECONDS);
 
-        verify(clientEventHandler, only()).httpRequestInvalid(any(Request.class), any(Throwable.class));
+        verify(clientEventHandler, only()).httpRequestInvalid(any(Request.class), any(Response.class), any(Throwable.class));
     }
 
     @Test


### PR DESCRIPTION
Hi!
We overloaded ClientEventCallback interface methods to be able to path some additional information (path and responseCode) to implementation. This information can be useful for example for monitoring.