### PR TITLE
Fix breaking test and upgrade TestContainers for M1 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <okhttp.version>4.9.0</okhttp.version>
         <slf4j.version>1.7.30</slf4j.version>
         <logback.version>1.2.3</logback.version>
-        <testcontainers.version>1.15.1</testcontainers.version>
+        <testcontainers.version>1.17.6</testcontainers.version>
     </properties>
     <distributionManagement>
         <snapshotRepository>
@@ -260,7 +260,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>${java.version}</release>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/itest/java/com/orbitz/consul/CatalogITest.java
+++ b/src/itest/java/com/orbitz/consul/CatalogITest.java
@@ -1,16 +1,9 @@
 package com.orbitz.consul;
 
-import com.orbitz.consul.async.ConsulResponseCallback;
-import com.orbitz.consul.model.ConsulResponse;
-import com.orbitz.consul.model.catalog.*;
-import com.orbitz.consul.model.health.ImmutableService;
-import com.orbitz.consul.model.health.Node;
-import com.orbitz.consul.model.health.Service;
-import com.orbitz.consul.model.health.ServiceHealth;
-import com.orbitz.consul.option.ImmutableQueryOptions;
-import com.orbitz.consul.option.QueryOptions;
-import org.junit.Ignore;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.math.BigInteger;
 import java.net.UnknownHostException;
@@ -24,7 +17,25 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.*;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.orbitz.consul.async.ConsulResponseCallback;
+import com.orbitz.consul.model.ConsulResponse;
+import com.orbitz.consul.model.catalog.CatalogDeregistration;
+import com.orbitz.consul.model.catalog.CatalogNode;
+import com.orbitz.consul.model.catalog.CatalogRegistration;
+import com.orbitz.consul.model.catalog.CatalogService;
+import com.orbitz.consul.model.catalog.ImmutableCatalogDeregistration;
+import com.orbitz.consul.model.catalog.ImmutableCatalogRegistration;
+import com.orbitz.consul.model.catalog.ImmutableCatalogService;
+import com.orbitz.consul.model.catalog.ImmutableServiceWeights;
+import com.orbitz.consul.model.health.ImmutableService;
+import com.orbitz.consul.model.health.Node;
+import com.orbitz.consul.model.health.Service;
+import com.orbitz.consul.model.health.ServiceHealth;
+import com.orbitz.consul.option.ImmutableQueryOptions;
+import com.orbitz.consul.option.QueryOptions;
 
 public class CatalogITest extends BaseIntegrationTest {
 
@@ -284,7 +295,7 @@ public class CatalogITest extends BaseIntegrationTest {
 
         String nodeName = "node";
         String serviceName = UUID.randomUUID().toString();
-        String serviceId = createAutoDeregisterServiceId();
+        String serviceId = UUID.randomUUID().toString();
         String catalogId = UUID.randomUUID().toString();
 
         CatalogRegistration registration = ImmutableCatalogRegistration.builder()


### PR DESCRIPTION
- shouldGetNodeInCallback() in CatalogITest was using createAutoDeregisterServiceId() which adds to the list of agent registered services which is attempted to be deregistered in cleanup. The /catalog/services endpoint returns an aggregated list of services registered with each agent across the data center. The /agent/services endpoint _will only return services registered against the specific local agent with which you are communicating_. This test was not reliable in this regard as the registered catalog service was not found in the agent list of registered services and erroring.
- Upgraded testcontainers.version from 1.15.1 to 1.17.6 so M1 support exists